### PR TITLE
Disable tzdetect which is crashing Firefox on Windows.

### DIFF
--- a/lib/mixin/index.js
+++ b/lib/mixin/index.js
@@ -9,10 +9,6 @@ module.exports = function( i18n ) {
 
 		translate: i18n.translate.bind( i18n ),
 
-		componentWillMount: function() {
-			i18n.moment.tz.setDefault( tzDetect() );
-		},
-
 		componentDidMount: function() {
 			i18n.stateObserver.addListener( 'change', this.updateTranslation );
 			i18n.componentUpdateHooks.forEach( function( hook ) {


### PR DESCRIPTION
A recurring problem has popped up for Calypso users since `i18n-calypso` was merged in.  Many users have reported an un-responsive script in Firefox on Windows ( https://github.com/Automattic/wp-calypso/issues/5879 ).  I was able to consistently reproduce the problem in production and locally when visiting the reader first, then clicking on "My Sites".

The Firefox debugger traced the un-responsive script back to [this call](https://github.com/Automattic/i18n-calypso/blob/master/lib/mixin/index.js#L13).  In my testing on Firefox on Windows, the tzdetect call was always returning null, but is called *every time* the i18n mixin is used.  So even if the library was returning valuable data, the manner in which it is called when every component mounts should likely be re-evaluated.

Here is the output of `console.log`ing all the calls to `jstimezonedetect` on the Stats Insights page:

![tz-lotsa](https://cloud.githubusercontent.com/assets/22080/15941890/f97b32de-2e36-11e6-8ed4-8fc4a0b2770b.gif)

Rather than implement a fix in this PR, I suggest we disable this call altogether to ensure Firefox/Windows users are no longer negatively impacted
