### PR TITLE
Tests: Update for React 15

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -140,7 +140,7 @@ describe( 'I18n', function() {
 		} );
 
 		describe( 'with mixed components', function() {
-			it( 'should handle sprintf and compoment interpolation together', function() {
+			it( 'should handle sprintf and component interpolation together', function() {
 				var input = React.DOM.input(),
 					expectedResultString = '<span><span>foo </span><input/><span> bar</span></span>',
 					placeholder = 'bar',

--- a/test/index.js
+++ b/test/index.js
@@ -142,7 +142,7 @@ describe( 'I18n', function() {
 		describe( 'with mixed components', function() {
 			it( 'should handle sprintf and component interpolation together', function() {
 				var input = React.DOM.input(),
-					expectedResultString = '<span><span>foo </span><input/><span> bar</span></span>',
+					expectedResultString = '<span>foo <input/> bar</span>',
 					placeholder = 'bar',
 					translatedComponent = translate( 'foo {{ input /}} %(placeholder)s', {
 						components: {
@@ -154,7 +154,7 @@ describe( 'I18n', function() {
 					} ),
 					instance = React.createElement('span', null, translatedComponent);
 
-				assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToString( instance ) ) );
+				assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( instance ) ) );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Use renderToStaticMarkup to avoid `react-dataroot` attribute being added,
and take into account that React 15 doesn't auto-add `<span>`s around text
anymore, see https://facebook.github.io/react/blog/2016/04/07/react-v15.html#no-more-extra-ltspangts

This is basically Automattic/wp-calypso@b14809a
which seems to have been lost when moving i18n-calypso to its own repo.

cc @Tug for review