### PR TITLE
Bump interpolate-components to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/Automattic/i18n-calypso#readme",
   "dependencies": {
     "debug": "2.2.0",
-    "interpolate-components": "1.0.5",
+    "interpolate-components": "1.1.0",
     "jed": "1.0.2",
     "jstimezonedetect": "1.0.5",
     "lodash.assign": "^4.0.8",


### PR DESCRIPTION
Which is the first version to use Babel 6.

Needs #4 to be merged first.

cc @Tug for review