### PR TITLE
Fix TypeError: `interpolateComponents is not a function`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var debug = require( 'debug' )( 'i18n-calypso' ),
 	Jed = require( 'jed' ),
 	moment = require( 'moment-timezone' ),
 	EventEmitter = require( 'events' ).EventEmitter,
-	interpolateComponents = require( 'interpolate-components' ),
+	interpolateComponents = require( 'interpolate-components' ).default,
 	LRU = require( 'lru-cache' ),
 	assign = require( 'lodash.assign' );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/6121. I guess we need to release 1.3.1 with this fix. :-/

cc @gwwar @Tug