### PR TITLE
Allow adding translations to an existing jed object

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
 	setLocale: i18n.setLocale.bind( i18n ),
 	getLocale: i18n.getLocale.bind( i18n ),
 	getLocaleSlug: i18n.getLocaleSlug.bind( i18n ),
+	addTranslations: i18n.addTranslations.bind( i18n ),
 	reRenderTranslations: i18n.reRenderTranslations.bind( i18n ),
 	registerComponentUpdateHook: i18n.registerComponentUpdateHook.bind( i18n ),
 	registerTranslateHook: i18n.registerTranslateHook.bind( i18n ),

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,6 +227,22 @@ I18N.prototype.getLocaleSlug = function() {
 	return this.state.localeSlug;
 };
 
+
+/**
+ * Adds new translations to the locale data, overwriting any existing translations with a matching key
+ **/
+I18N.prototype.addTranslations = function( localeData ) {
+	for ( var prop in localeData ) {
+		if ( prop !== '' ) {
+			this.state.jed.options.locale_data.messages[prop] = localeData[prop];
+		}
+	}
+
+	this.state.translations.reset();
+	this.stateObserver.emit( 'change' );
+};
+
+
 /**
  * Exposes single translation method, which is converted into its respective Jed method.
  * See sibling README

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -23,6 +23,10 @@ var locale = {
 		null,
 		'translation4'
 	],
+	'test-will-overwrite': [
+		null,
+		'translation1'
+	],
 	'Featured': [
 		null,
 		'translation-without-context'

--- a/test/index.js
+++ b/test/index.js
@@ -171,6 +171,29 @@ describe( 'I18n', function() {
 				assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( instance ) ) );
 			} );
 		} );
+
+		describe( 'adding new translations', function() {
+			it( 'should find a new translation after it has been added', function() {
+				i18n.addTranslations( {
+					'test-does-not-exist': [
+						null,
+						'translation3'
+					]
+				} );
+
+				assert.equal( 'translation3', translate( 'test-does-not-exist' ) );
+			} );
+			it( 'should return the new translation if it has been overwritten', function() {
+				i18n.addTranslations( {
+					'test-will-overwrite': [
+						null,
+						'not-translation1'
+					]
+				} );
+
+				assert.equal( 'not-translation1', translate( 'test-will-overwrite' ) );
+			} );
+		} );
 	} );
 
 	describe( 'moment()', function() {


### PR DESCRIPTION
This introduces `addTranslations()` which takes a translations object and adds it do the existing one. Fixes #8 