### PR TITLE
Add verbatim line breaks to the PO header

### DIFF
--- a/cli/formatters/pot.js
+++ b/cli/formatters/pot.js
@@ -85,15 +85,15 @@ module.exports = function( matches, options ) {
 	output += options.potHeader || [
 			'msgid ""',
 			'msgstr ""',
-			'"Project-Id-Version: _s ' + ( options.projectName || '' ) + '"',
-			'"Report-Msgid-Bugs-To: ' + ( options.projectBugsUrl || '' ) + '"',
-			'"POT-Creation-Date: ' + new Date().toISOString() + '"',
-			'"MIME-Version: 1.0"',
-			'"Content-Type: text/plain; charset=UTF-8"',
-			'"Content-Transfer-Encoding: 8bit"',
-			'"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE"',
-			'"Last-Translator: FULL NAME <EMAIL@ADDRESS>"',
-			'"Language-Team: LANGUAGE <LL@li.org>"',
+			'"Project-Id-Version: _s ' + ( options.projectName || '' ) + '\\n"',
+			'"Report-Msgid-Bugs-To: ' + ( options.projectBugsUrl || '' ) + '\\n"',
+			'"POT-Creation-Date: ' + new Date().toISOString() + '\\n"',
+			'"MIME-Version: 1.0\\n"',
+			'"Content-Type: text/plain; charset=UTF-8\\n"',
+			'"Content-Transfer-Encoding: 8bit\\n"',
+			'"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\\n"',
+			'"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"',
+			'"Language-Team: LANGUAGE <LL@li.org>\\n"',
 			''
 		].join( '\n' );
 

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -211,15 +211,15 @@ describe( 'index', function() {
 		} );
 
 		it( 'should have all the default headers', function() {
-			expect( output ).to.have.string( '"Project-Id-Version: _s i18nTest"\n' );
+			expect( output ).to.have.string( '"Project-Id-Version: _s i18nTest\\n"\n' );
 			expect( output ).to.have.string( '"Report-Msgid-Bugs-To:' );
 			expect( output ).to.have.string( '"POT-Creation-Date:' );
-			expect( output ).to.have.string( '"MIME-Version: 1.0"\n' );
-			expect( output ).to.have.string( '"Content-Type: text/plain; charset=UTF-8"\n' );
-			expect( output ).to.have.string( '"Content-Transfer-Encoding: 8bit"\n' );
+			expect( output ).to.have.string( '"MIME-Version: 1.0\\n"\n' );
+			expect( output ).to.have.string( '"Content-Type: text/plain; charset=UTF-8\\n"\n' );
+			expect( output ).to.have.string( '"Content-Transfer-Encoding: 8bit\\n"\n' );
 			expect( output ).to.have.string( '"PO-Revision-Date:' );
-			expect( output ).to.have.string( '"Last-Translator: FULL NAME <EMAIL@ADDRESS>"\n' );
-			expect( output ).to.have.string( '"Language-Team: LANGUAGE <LL@li.org>"\n' );
+			expect( output ).to.have.string( '"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"\n' );
+			expect( output ).to.have.string( '"Language-Team: LANGUAGE <LL@li.org>\\n"\n' );
 		} );
 
 		it( 'should create a simple translation', function() {

--- a/test/cli/pot.pot
+++ b/test/cli/pot.pot
@@ -2,15 +2,15 @@
 
 msgid ""
 msgstr ""
-Project-Id-Version: _s i18nTest
-Report-Msgid-Bugs-To:
-POT-Creation-Date: 2016-04-25T01:50:44.330Z
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
-PO-Revision-Date: 2014-MO-DA HO:MI+ZONE
-Last-Translator: FULL NAME <EMAIL@ADDRESS>
-Language-Team: LANGUAGE <LL@li.org>
+"Project-Id-Version: _s i18nTest\n"
+"Report-Msgid-Bugs-To:\n"
+"POT-Creation-Date: 2016-04-25T01:50:44.330Z\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 
 msgid "My hat has three corners."
 msgstr ""


### PR DESCRIPTION
A standard PO file header has each line of the header ending by a printed `\n`, see http://pology.nedohodnik.net/doc/user/en_US/ch-poformat.html#sec-poheader

This adds those and in the tests accordingly.