### PR TITLE
Include locations of the strings in the output

### DIFF
--- a/cli/formatters/php.js
+++ b/cli/formatters/php.js
@@ -34,6 +34,7 @@ function getGlotPressFunction( properties ) {
 function buildPHPString( properties, textdomain ) {
 	var wpFunc = getGlotPressFunction( properties ),
 		response = [],
+		string,
 		closing = textdomain ? ( ', "' + textdomain.replace( /"/g, '\\"' ) + '" ),' ) : ' ),',
 		stringFromFunc = {
 			__: '__( ' + properties.single + closing,
@@ -48,7 +49,13 @@ function buildPHPString( properties, textdomain ) {
 		response.push( '/* translators: ' + properties.comment.replace( /\*\//g, '*\\/' ) + ' */' );
 	}
 
-	response.push( stringFromFunc[ wpFunc ] );
+	string = stringFromFunc[ wpFunc ];
+
+	if ( properties.line ) {
+		string += ' // ' + properties.line;
+	}
+
+	response.push( string );
 
 	return response.join( '\n' );
 }

--- a/cli/preprocess-xgettextjs-match.js
+++ b/cli/preprocess-xgettextjs-match.js
@@ -12,7 +12,7 @@
  * @return {object} data object combining the strings and options passed into translate();
  */
 module.exports = function preProcessXGettextJSMatch( match ) {
-	var finalProps = {},
+	var finalProps = { line: match.line },
 		options, i, keyName, args;
 
 	if ( ! match.arguments.length ) {

--- a/test/cli/examples/i18n-test-examples.jsx
+++ b/test/cli/examples/i18n-test-examples.jsx
@@ -63,6 +63,10 @@ function test() {
 
 	content = this.translate( 'The string key text',
 		{ 'context': 'context with a literal string key' } );
+
+	i18n.translate( 'My hat has three corners.', {
+		'comment': 'Second ocurrence'
+	} );
 }
 
 module.exports = test;

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -239,6 +239,14 @@ describe( 'index', function() {
 			expect( output ).to.have.string( '#. draft saved date format, see http://php.net/date' );
 		} );
 
+		it( 'should prepend the line number', function() {
+			expect( output ).to.have.string( '#: test/cli/out/i18n-test-examples.js:9\nmsgid "My hat has three corners too."' );
+		} );
+
+		it( 'should combine strings', function() {
+			expect( output ).to.have.string( '#: test/cli/out/i18n-test-examples.js:6\n#: test/cli/out/i18n-test-examples.js:68\n#. Second ocurrence\nmsgid "My hat has three corners."' );
+		} );
+
 		it( 'should pass through an sprintf as a regular translation', function() {
 			expect( output ).to.have.string( 'msgid "Your city is %(city)s and your zip is %(zip)s."\nmsgstr ""\n' );
 		} );
@@ -312,6 +320,10 @@ describe( 'index', function() {
 
 		it( 'should prepend a translator comment', function() {
 			expect( output ).to.have.string( '/* translators: draft saved date format, see http://php.net/date */\n__( "g:i:s a" ),' );
+		} );
+
+		it( 'should append the line number', function() {
+			expect( output ).to.have.string( '__( "My hat has three corners." ), // test/cli/out/i18n-test-examples.js:6' );
 		} );
 
 		it( 'should pass through an sprintf as a regular __() method', function() {

--- a/test/cli/pot.pot
+++ b/test/cli/pot.pot
@@ -3,8 +3,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: _s i18nTest\n"
-"Report-Msgid-Bugs-To:\n"
-"POT-Creation-Date: 2016-04-25T01:50:44.330Z\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-07-28T12:24:03.104Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,135 +12,113 @@ msgstr ""
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
+#: test/cli/out/i18n-test-examples.js:6
+#: test/cli/out/i18n-test-examples.js:68
+#. Second ocurrence
 msgid "My hat has three corners."
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:9
 msgid "My hat has three corners too."
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:13
 msgid "My hat has three corners."
 msgid_plural "My hats have three corners."
 msgstr[0] ""
 msgstr[1] ""
 
+#: test/cli/out/i18n-test-examples.js:22
 msgctxt "verb"
 msgid "post"
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:28
 msgctxt "verb2"
 msgid "post2"
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:31
 #. draft saved date format, see http://php.net/date
 msgid "g:i:s a"
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:44
 msgid "Your city is %(city)s and your zip is %(zip)s."
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:53
 msgid "single test"
 msgid_plural "plural test"
 msgstr[0] ""
 msgstr[1] ""
 
+#: test/cli/out/i18n-test-examples.js:57
 msgid "single test2"
 msgid_plural "plural test2"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "This is a multi-line translation with \$1mixed quotes\$1 and mixed 'single quotes'"
+#: test/cli/out/i18n-test-examples.js:63
+msgid ""
+"This is a multi-line translation with \"mixed quotes\" and mixed 'single "
+"quotes'"
 msgstr ""
 
+#: test/cli/out/i18n-test-examples.js:66
 msgctxt "context with a literal string key"
 msgid "The string key text"
 msgstr ""
 
+#: test/cli/out/i18n-test-example-second-file.js:6
 msgid "My test has two files."
 msgstr ""
 
+#: extras/date.js:4
 msgctxt "future time"
 msgid "in %s"
 msgstr ""
 
+#: extras/date.js:5
 msgid "a few seconds"
 msgstr ""
 
+#: extras/date.js:6
 msgid "a minute"
 msgstr ""
 
+#: extras/date.js:7
 msgid "%d minutes"
 msgstr ""
 
+#: extras/date.js:8
 msgid "%d hours"
 msgstr ""
 
+#: extras/date.js:9
 msgid "%d days"
 msgstr ""
 
+#: extras/date.js:10
 msgid "a month"
 msgstr ""
 
+#: extras/date.js:11
 msgid "%d months"
 msgstr ""
 
+#: extras/date.js:12
 msgid "a year"
 msgstr ""
 
+#: extras/date.js:13
 msgid "%d years"
 msgstr ""
 
-msgctxt "momentjs format string (for LT)"
-msgid "HH:mm"
+#: extras/date.js:17
+msgid "number_format_thousands_sep"
 msgstr ""
 
-msgctxt "momentjs format string (for L)"
-msgid "DD/MM/YYYY"
-msgstr ""
-
-msgctxt "momentjs format string (for LL)"
-msgid "D MMMM YYYY"
-msgstr ""
-
-msgctxt "momentjs format string (for LLL)"
-msgid "D MMMM YYYY LT"
-msgstr ""
-
-msgctxt "momentjs format string (for LLLL)"
-msgid "dddd, D MMMM YYYY LT"
-msgstr ""
-
-msgctxt "momentjs format string (for MMM D)"
-msgid "MMM D"
-msgstr ""
-
-msgctxt "momentjs format string (sameDay)"
-msgid "[Today at] LT"
-msgstr ""
-
-msgctxt "momentjs format string (nextDay)"
-msgid "[Tomorrow at] LT"
-msgstr ""
-
-msgctxt "momentjs format string (nextWeek)"
-msgid "dddd [at] LT"
-msgstr ""
-
-msgctxt "momentjs format string (lastDay)"
-msgid "[Yesterday at] LT"
-msgstr ""
-
-msgctxt "momentjs format string (lastWeek)"
-msgid "[Last] dddd [at] LT"
-msgstr ""
-
-msgctxt "momentjs format string (sameElse)"
-msgid "L"
-msgstr ""
-
-msgctxt "momentjs setting"
-msgid "num_first_day_of_week"
-msgstr ""
-
-msgctxt "momentjs setting"
-msgid "num_day_of_year"
+#: extras/date.js:19
+msgid "number_format_decimal_point"
 msgstr ""

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -19,6 +19,10 @@ var locale = {
 		null,
 		'translation3'
 	],
+	'test4': [
+		null,
+		'translation4'
+	],
 	'Featured': [
 		null,
 		'translation-without-context'

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,20 @@ describe( 'I18n', function() {
 			} );
 		} );
 
+		describe( 'translate with comments', function() {
+			it( 'should find a string with comment', function() {
+				assert.equal( 'translation4', translate( {
+					original: 'test4',
+					comment: 'thecomment'
+				} ) );
+			} );
+			it( 'should allow original text as options attribute or initial argument', function() {
+				assert.equal( 'translation4', translate( 'test4', {
+					comment: 'thecomment'
+				} ) );
+			} );
+		} );
+
 		describe( 'plural translation', function() {
 			it( 'should use the singular form for one item', function() {
 				assert.equal( 'plural-test singular translation', translate( {


### PR DESCRIPTION
The [`pot.pot`](https://github.com/Automattic/i18n-calypso/pull/12/files#diff-7458440ce119e7b6ea3c3c9315e79f46) has an example, it now includes entries like:

```
#: test/cli/out/i18n-test-examples.js:6
msgid "My hat has three corners."
msgstr ""
```

The PHP output now looks like this:
```
__( "My hat has three corners." ), // test/cli/out/i18n-test-examples.js:6
```