### PR TITLE
Enable POT generation from the Calypso source

### DIFF
--- a/cli/formatters/pot.js
+++ b/cli/formatters/pot.js
@@ -55,8 +55,7 @@ function multiline( literal, startAt ) {
 }
 
 function uniqueMatchId( match ) {
-	return ( match.plural ? 'p' : 's' ) +
-		' msgid=' + ( match.plural || match.single ) +
+	return ' msgid=' + ( match.single ) +
 		' ctxt=' + ( match.context || '' );
 }
 
@@ -115,6 +114,11 @@ module.exports = function( matches, options ) {
 		}
 		if ( match.comment ) {
 			uniqueMatchesMap[ matchId ].comments[ match.comment ] = true;
+		}
+
+		if ( ! uniqueMatchesMap[ matchId ].plural && match.plural ) {
+			// We group singular only-s and version with plurals, so make sure that we keep the plural
+			uniqueMatchesMap[ matchId ].plural = match.plural;
 		}
 
 		// ignore this match now that we have updated the first match

--- a/cli/index.js
+++ b/cli/index.js
@@ -34,7 +34,8 @@ module.exports = function( config ) {
 	}
 
 	parser = new Xgettext( {
-		keywords: parserKeywords
+		keywords: parserKeywords,
+		parseOptions: { plugins: [ 'jsx', 'classProperties', 'objectRestSpread', 'exportExtensions', 'trailingFunctionCommas', 'asyncFunctions' ], allowImportExportEverywhere: true }
 	} );
 
 	function getFileMatches( inputFiles ) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "0.14.8 || ^15.1.0",
     "async": "^1.5.2",
     "commander": "^2.9.0",
-    "xgettext-js": "^0.3.0"
+    "xgettext-js": "^1.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.7",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,9 @@
     "react": "0.14.8 || ^15.1.0",
     "async": "^1.5.2",
     "commander": "^2.9.0",
-    "xgettext-js": "^1.0.0"
+    "xgettext-js": "1.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.7.7",
-    "babel-preset-react": "^6.5.0",
     "chai": "^3.5.0",
     "enzyme": "2.2.0",
     "mocha": "^2.4.5",

--- a/test/cli/examples/i18n-test-examples.jsx
+++ b/test/cli/examples/i18n-test-examples.jsx
@@ -12,11 +12,14 @@ function test() {
 	var numHats = howManyHats(); // returns integer
 	content = i18n.translate( {
 		original: {
-			single: 'My hat has three corners.',
-			plural: 'My hats have three corners.',
+			single: 'My hat has four corners.',
+			plural: 'My hats have five corners.',
 			count: numHats
 		}
 	} );
+
+	// Should be merged in POT with the pluralized form
+	content = i18n.translate( { original: 'My hat has four corners.' } );
 
 	// providing context
 	content = i18n.translate( {

--- a/test/cli/examples/i18n-test-examples.jsx
+++ b/test/cli/examples/i18n-test-examples.jsx
@@ -21,6 +21,12 @@ function test() {
 	// Should be merged in POT with the pluralized form
 	content = i18n.translate( { original: 'My hat has four corners.' } );
 
+	// Should catch template literals
+	content = i18n.translate( `My hat has six corners.` );
+	content = i18n.translate( `My hat
+has seventeen
+corners.` );
+
 	// providing context
 	content = i18n.translate( {
 		original: 'post',

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -227,7 +227,11 @@ describe( 'index', function() {
 		} );
 
 		it( 'should create a plural translation', function() {
-			expect( output ).to.have.string( 'msgid "My hat has three corners."\nmsgid_plural "My hats have three corners."\nmsgstr[0] ""\n' );
+			expect( output ).to.have.string( 'msgid "My hat has four corners."\nmsgid_plural "My hats have five corners."\nmsgstr[0] ""\n' );
+		} );
+
+		it( 'should combine singular with plural translation', function() {
+			expect( output ).not.to.have.string( 'msgid "My hat has four corners."\nmsgstr ""\n' );
 		} );
 
 		it( 'should create a context translation', function() {
@@ -307,7 +311,7 @@ describe( 'index', function() {
 		} );
 
 		it( 'should create a plural _n() translation', function() {
-			expect( output ).to.have.string( '_n( "My hat has three corners.", "My hats have three corners.", 1 ),' );
+			expect( output ).to.have.string( '_n( "My hat has four corners.", "My hats have five corners.", 1 ),' );
 		} );
 
 		it( 'should create a context _x() translation', function() {

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -244,7 +244,7 @@ describe( 'index', function() {
 		} );
 
 		it( 'should combine strings', function() {
-			expect( output ).to.have.string( '#: test/cli/out/i18n-test-examples.js:6\n#: test/cli/out/i18n-test-examples.js:68\n#. Second ocurrence\nmsgid "My hat has three corners."' );
+			expect( output ).to.match( /#: test\/cli\/out\/i18n-test-examples.js:\d+\n#: test\/cli\/out\/i18n-test-examples.js:\d+\n#. Second ocurrence\nmsgid "My hat has three corners."/ );
 		} );
 
 		it( 'should pass through an sprintf as a regular translation', function() {

--- a/test/cli/pot.pot
+++ b/test/cli/pot.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: _s i18nTest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-01T14:01:27.859Z\n"
+"POT-Creation-Date: 2016-08-03T05:46:30.666Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,66 +12,74 @@ msgstr ""
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
-#: test/cli/out/i18n-test-examples.js:71
-#: test/cli/out/i18n-test-examples.js:6
+#: test/cli/examples/i18n-test-examples.jsx:76
+#: test/cli/examples/i18n-test-examples.jsx:6
 #. Second ocurrence
 msgid "My hat has three corners."
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:69
+#: test/cli/examples/i18n-test-examples.jsx:73
 msgctxt "context with a literal string key"
 msgid "The string key text"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:66
+#: test/cli/examples/i18n-test-examples.jsx:68
 msgid ""
 "This is a multi-line translation with \"mixed quotes\" and mixed 'single "
 "quotes'"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:60
+#: test/cli/examples/i18n-test-examples.jsx:65
 msgid "single test2"
 msgid_plural "plural test2"
 msgstr[0] ""
 msgstr[1] ""
 
-#: test/cli/out/i18n-test-examples.js:56
+#: test/cli/examples/i18n-test-examples.jsx:61
 msgid "single test"
 msgid_plural "plural test"
 msgstr[0] ""
 msgstr[1] ""
 
-#: test/cli/out/i18n-test-examples.js:47
+#: test/cli/examples/i18n-test-examples.jsx:52
 msgid "Your city is %(city)s and your zip is %(zip)s."
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:34
+#: test/cli/examples/i18n-test-examples.jsx:40
 #. draft saved date format, see http://php.net/date
 msgid "g:i:s a"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:31
+#: test/cli/examples/i18n-test-examples.jsx:37
 msgctxt "verb2"
 msgid "post2"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:25
+#: test/cli/examples/i18n-test-examples.jsx:31
 msgctxt "verb"
 msgid "post"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:22
-#: test/cli/out/i18n-test-examples.js:13
+#: test/cli/examples/i18n-test-examples.jsx:26
+msgid "My hat has seventeen corners."
+msgstr ""
+
+#: test/cli/examples/i18n-test-examples.jsx:25
+msgid "My hat has six corners."
+msgstr ""
+
+#: test/cli/examples/i18n-test-examples.jsx:22
+#: test/cli/examples/i18n-test-examples.jsx:13
 msgid "My hat has four corners."
 msgid_plural "My hats have five corners."
 msgstr[0] ""
 msgstr[1] ""
 
-#: test/cli/out/i18n-test-examples.js:9
+#: test/cli/examples/i18n-test-examples.jsx:9
 msgid "My hat has three corners too."
 msgstr ""
 
-#: test/cli/out/i18n-test-example-second-file.js:6
+#: test/cli/examples/i18n-test-example-second-file.jsx:6
 msgid "My test has two files."
 msgstr ""
 

--- a/test/cli/pot.pot
+++ b/test/cli/pot.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: _s i18nTest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-28T12:24:03.104Z\n"
+"POT-Creation-Date: 2016-08-01T14:01:27.859Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,113 +12,114 @@ msgstr ""
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
+#: test/cli/out/i18n-test-examples.js:71
 #: test/cli/out/i18n-test-examples.js:6
-#: test/cli/out/i18n-test-examples.js:68
 #. Second ocurrence
 msgid "My hat has three corners."
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:9
-msgid "My hat has three corners too."
+#: test/cli/out/i18n-test-examples.js:69
+msgctxt "context with a literal string key"
+msgid "The string key text"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:13
-msgid "My hat has three corners."
-msgid_plural "My hats have three corners."
-msgstr[0] ""
-msgstr[1] ""
-
-#: test/cli/out/i18n-test-examples.js:22
-msgctxt "verb"
-msgid "post"
-msgstr ""
-
-#: test/cli/out/i18n-test-examples.js:28
-msgctxt "verb2"
-msgid "post2"
-msgstr ""
-
-#: test/cli/out/i18n-test-examples.js:31
-#. draft saved date format, see http://php.net/date
-msgid "g:i:s a"
-msgstr ""
-
-#: test/cli/out/i18n-test-examples.js:44
-msgid "Your city is %(city)s and your zip is %(zip)s."
-msgstr ""
-
-#: test/cli/out/i18n-test-examples.js:53
-msgid "single test"
-msgid_plural "plural test"
-msgstr[0] ""
-msgstr[1] ""
-
-#: test/cli/out/i18n-test-examples.js:57
-msgid "single test2"
-msgid_plural "plural test2"
-msgstr[0] ""
-msgstr[1] ""
-
-#: test/cli/out/i18n-test-examples.js:63
+#: test/cli/out/i18n-test-examples.js:66
 msgid ""
 "This is a multi-line translation with \"mixed quotes\" and mixed 'single "
 "quotes'"
 msgstr ""
 
-#: test/cli/out/i18n-test-examples.js:66
-msgctxt "context with a literal string key"
-msgid "The string key text"
+#: test/cli/out/i18n-test-examples.js:60
+msgid "single test2"
+msgid_plural "plural test2"
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/cli/out/i18n-test-examples.js:56
+msgid "single test"
+msgid_plural "plural test"
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/cli/out/i18n-test-examples.js:47
+msgid "Your city is %(city)s and your zip is %(zip)s."
+msgstr ""
+
+#: test/cli/out/i18n-test-examples.js:34
+#. draft saved date format, see http://php.net/date
+msgid "g:i:s a"
+msgstr ""
+
+#: test/cli/out/i18n-test-examples.js:31
+msgctxt "verb2"
+msgid "post2"
+msgstr ""
+
+#: test/cli/out/i18n-test-examples.js:25
+msgctxt "verb"
+msgid "post"
+msgstr ""
+
+#: test/cli/out/i18n-test-examples.js:22
+#: test/cli/out/i18n-test-examples.js:13
+msgid "My hat has four corners."
+msgid_plural "My hats have five corners."
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/cli/out/i18n-test-examples.js:9
+msgid "My hat has three corners too."
 msgstr ""
 
 #: test/cli/out/i18n-test-example-second-file.js:6
 msgid "My test has two files."
 msgstr ""
 
-#: extras/date.js:4
-msgctxt "future time"
-msgid "in %s"
-msgstr ""
-
-#: extras/date.js:5
-msgid "a few seconds"
-msgstr ""
-
-#: extras/date.js:6
-msgid "a minute"
-msgstr ""
-
-#: extras/date.js:7
-msgid "%d minutes"
-msgstr ""
-
-#: extras/date.js:8
-msgid "%d hours"
-msgstr ""
-
-#: extras/date.js:9
-msgid "%d days"
-msgstr ""
-
-#: extras/date.js:10
-msgid "a month"
-msgstr ""
-
-#: extras/date.js:11
-msgid "%d months"
-msgstr ""
-
-#: extras/date.js:12
-msgid "a year"
-msgstr ""
-
-#: extras/date.js:13
-msgid "%d years"
+#: extras/date.js:19
+msgid "number_format_decimal_point"
 msgstr ""
 
 #: extras/date.js:17
 msgid "number_format_thousands_sep"
 msgstr ""
 
-#: extras/date.js:19
-msgid "number_format_decimal_point"
+#: extras/date.js:13
+msgid "%d years"
+msgstr ""
+
+#: extras/date.js:12
+msgid "a year"
+msgstr ""
+
+#: extras/date.js:11
+msgid "%d months"
+msgstr ""
+
+#: extras/date.js:10
+msgid "a month"
+msgstr ""
+
+#: extras/date.js:9
+msgid "%d days"
+msgstr ""
+
+#: extras/date.js:8
+msgid "%d hours"
+msgstr ""
+
+#: extras/date.js:7
+msgid "%d minutes"
+msgstr ""
+
+#: extras/date.js:6
+msgid "a minute"
+msgstr ""
+
+#: extras/date.js:5
+msgid "a few seconds"
+msgstr ""
+
+#: extras/date.js:4
+msgctxt "future time"
+msgid "in %s"
 msgstr ""


### PR DESCRIPTION
This enables parsing of [babylon parser output](https://www.npmjs.com/package/babylon#output) which comes through https://github.com/Automattic/xgettext-js/pull/11.

The main changes that need accomodation:
- `Literal` is split into subliterals of which we are only interested in `StringLiteral`
- the `raw` property was moved into `extra.raw`
- we need to also check for `StringLiteral` in an `innerProp`

This is in order to make https://github.com/Automattic/wp-calypso/pull/7152 possible.