### PR TITLE
Fix POT rendering of line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+1.6.1
+-----
+Fix invalid POT output when strings contained a line break, see [#14](https://github.com/Automattic/i18n-calypso/pull/14).
+
 1.6.0
 -----
-- Add method to add/overwrite translations, see [#12](https://github.com/Automattic/i18n-calypso/pull/12).
+- Add method to add/overwrite translations, see [#10](https://github.com/Automattic/i18n-calypso/pull/10).
 - Add ability to parse Calypso source by switching to xgettext-js 1.0.0 and enabling the necessary plugins, see [#13](https://github.com/Automattic/i18n-calypso/pull/13).
 
 1.5.0
 -----
-- POT: enable output of string locations, see [#11](https://github.com/Automattic/i18n-calypso/pull/12).
+- POT: enable output of string locations, see [#12](https://github.com/Automattic/i18n-calypso/pull/12).

--- a/cli/formatters/pot.js
+++ b/cli/formatters/pot.js
@@ -24,6 +24,11 @@ function multiline( literal, startAt ) {
 		startAt = - 6;
 	}
 
+	// Remove line break in trailing backslash syntax.
+	literal = literal.replace( /\\\n/g, '' );
+	// Convert regular line breaks to \n notation.
+	literal = literal.replace( /\n/g, '\\n' );
+
 	if ( literal.length <= startAt + MAX_COLUMNS ) {
 		return literal.substr( startAt > 0 ? startAt : 0 );
 	}
@@ -158,6 +163,8 @@ module.exports = function( matches, options ) {
 
 		return matchPotStr;
 	} ).join( '\n' );
+
+	output += "\n# THIS IS THE END OF THE GENERATED FILE.\n";
 
 	return output;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -141,6 +141,8 @@ describe( 'index', function() {
 				format: 'POT',
 				extras: [ 'date' ]
 			} );
+
+			// fs.writeFileSync( path.join( __dirname, 'pot.pot' ), output, 'utf8' );
 		} );
 
 		it( 'should have all the default headers', function() {
@@ -219,7 +221,7 @@ describe( 'index', function() {
 
 		it( 'should handle template literals', function() {
 			expect( output ).to.have.string( 'msgid "My hat has six corners."' );
-			expect( output ).to.have.string( 'msgid "My hat\nhas seventeen\ncorners."' );
+			expect( output ).to.have.string( 'msgid "My hat\\nhas seventeen\\ncorners."' );
 		} );
 	} );
 

--- a/test/cli/pot.pot
+++ b/test/cli/pot.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: _s i18nTest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-03T05:46:30.666Z\n"
+"POT-Creation-Date: 2016-08-06T09:37:04.593Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -61,7 +61,7 @@ msgid "post"
 msgstr ""
 
 #: test/cli/examples/i18n-test-examples.jsx:26
-msgid "My hat has seventeen corners."
+msgid "My hat\nhas seventeen\ncorners."
 msgstr ""
 
 #: test/cli/examples/i18n-test-examples.jsx:25
@@ -131,3 +131,5 @@ msgstr ""
 msgctxt "future time"
 msgid "in %s"
 msgstr ""
+
+# THIS IS THE END OF THE GENERATED FILE.


### PR DESCRIPTION
Currently line breaks within strings lead to invalid POT files:
```
#: wp-calypso/client/my-sites/exporter/guided-transfer-details.jsx:28
msgid ""
"Have one of our Happiness Engineers {{strong}}transfer your
site{{/strong}} "
"to a self-hosted WordPress.org installation with
one of our hosting partners."
msgstr ""
```

This changes the output to:
```
#: wp-calypso/client/my-sites/exporter/guided-transfer-details.jsx:28
msgid ""
"Have one of our Happiness Engineers {{strong}}transfer your\nsite{{/strong}} "
"to a self-hosted WordPress.org installation with\none of our hosting "
"partners."
msgstr ""
```

It also handles this case:
```
#: wp-calypso/client/me/help/help-unverified-warning/index.jsx:37
msgid ""
"Trouble activating your account?\\
							Just click this button and we'll "
"resend the activation for you."
msgstr ""
```
new:
```
#: wp-calypso/client/me/help/help-unverified-warning/index.jsx:37
msgid ""
"Trouble activating your account? Just click this button and we'll resend the "
"activation for you."
msgstr ""
```

To make the output more compatible with the PHP output this also adds a comment at the end of the output file.