### PR TITLE
Add PHP template literal test

### DIFF
--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -305,6 +305,11 @@ describe( 'index', function() {
 		it( 'should find options with a literal string key', function() {
 			expect( output ).to.have.string( 'context with a literal string key' );
 		} );
+
+		it( 'should handle template literals', function() {
+			expect( output ).to.have.string( 'My hat has six corners.' );
+			expect( output ).to.have.string( '"My hat\nhas seventeen\ncorners."' );
+		} );
 	} );
 
 	describe( 'PHP with an additional textdomain parameter', function() {


### PR DESCRIPTION
This PR adds a test to ensure that string templates are handled correctly in the PHP format.

@akirk: I think the different levels of escaping in the PHP and POT tests is correct, but it still looks a bit weird.  Can I get a second opinion, please?
