### PR TITLE
Add support for glob in inputFiles

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -3,7 +3,9 @@
 /**
  * External dependencies/
  */
-var fs = require( 'fs' ),
+var flatten = require( 'lodash.flatten' ),
+	fs = require( 'fs' ),
+	glob = require( 'glob' ),
 	path = require( 'path' ),
 	program = require( 'commander' );
 
@@ -54,9 +56,9 @@ if ( outputFile ) {
 }
 
 // files relative to terminal location
-inputPaths = inputFiles.map( function( fileName ) {
-	return path.resolve( process.env.PWD, fileName );
-} );
+inputPaths = flatten( inputFiles.map( function( fileName ) {
+	return glob.sync( fileName, { cwd: process.env.PWD } );
+} ) );
 
 console.log( 'Reading inputFiles:\n\t- ' + inputPaths.join( '\n\t- ' ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,16 +20,18 @@
   },
   "homepage": "https://github.com/Automattic/i18n-calypso#readme",
   "dependencies": {
+    "async": "^1.5.2",
+    "commander": "^2.9.0",
     "debug": "2.2.0",
+    "glob": "^7.0.6",
     "interpolate-components": "1.1.0",
     "jed": "1.0.2",
     "jstimezonedetect": "1.0.5",
     "lodash.assign": "^4.0.8",
+    "lodash.flatten": "^4.4.0",
     "lru-cache": "4.0.1",
     "moment-timezone": "0.4.0",
     "react": "0.14.8 || ^15.1.0",
-    "async": "^1.5.2",
-    "commander": "^2.9.0",
     "xgettext-js": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds support for star patterns in the input filenames for the CLI.
You can now write:
```
i18n-calypso -i src/**/*.js -o output.pot
```
And it will scan your `src` folder recursively and look for all `.js` files.
