### PR TITLE
Replace LRU cache implementation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var debug = require( 'debug' )( 'i18n-calypso' ),
 	moment = require( 'moment-timezone' ),
 	EventEmitter = require( 'events' ).EventEmitter,
 	interpolateComponents = require( 'interpolate-components' ).default,
-	LRU = require( 'lru-cache' ),
+	LRU = require( 'lru' ),
 	assign = require( 'lodash.assign' );
 
 /**
@@ -211,7 +211,7 @@ I18N.prototype.setLocale = function( localeData ) {
 		this.state.numberFormatSettings.thousands_sep = ',';
 	}
 
-	this.state.translations.reset();
+	this.state.translations.clear();
 	this.stateObserver.emit( 'change' );
 };
 
@@ -238,7 +238,7 @@ I18N.prototype.addTranslations = function( localeData ) {
 		}
 	}
 
-	this.state.translations.reset();
+	this.state.translations.clear();
 	this.stateObserver.emit( 'change' );
 };
 
@@ -321,7 +321,7 @@ I18N.prototype.translate = function() {
  */
 I18N.prototype.reRenderTranslations = function() {
 	debug( 'Re-rendering all translations due to external request' );
-	this.state.translations.reset();
+	this.state.translations.clear();
 	this.stateObserver.emit( 'change' );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jstimezonedetect": "1.0.5",
     "lodash.assign": "^4.0.8",
     "lodash.flatten": "^4.4.0",
-    "lru-cache": "4.0.1",
+    "lru": "^3.1.0",
     "moment-timezone": "0.4.0",
     "react": "0.14.8 || ^15.1.0",
     "xgettext-js": "1.0.0"


### PR DESCRIPTION
`lru-cache` has as a dependency `pseudomap`, which has many outstanding PRs.
Specifically, https://github.com/isaacs/pseudomap/pull/6 preventing webpack2 processing it.
  
#### Testing instructions
  
* Include `i18n-calypso` in a webpack2 project, such as Delphin:
package json:
```json
    "i18n-calypso": "Automattic/i18n-calypso#update\/lru-implementation",
```

* build, in delphin `npm run start:static`, validate it succeeds
previously we would get:
```
SyntaxError: Unexpected token: punc (:) [bundle.cbeb532adbd6bab9833b.js:84105,13]
```
* Assert all tests pass
  
#### Additional notes


#### Reviews
  
- [x] Code
- [x] Product
- [x] Tests
   
@Automattic/sdev-feed
