### PR TITLE
Fix failing test

### DIFF
--- a/test/localize.js
+++ b/test/localize.js
@@ -22,7 +22,7 @@ describe( 'localize()', function() {
 
 		var LocalizedComponent = localize( MyComponent );
 
-		expect( LocalizedComponent.displayName ).to.equal( 'Localized' );
+		expect( LocalizedComponent.displayName ).to.equal( 'Localized' + MyComponent.name );
 	} );
 
 	it( 'should be named using the displayName of the composed component', function() {


### PR DESCRIPTION
This fixes a failing test:

```
1) localize() should be named using the variable name of the composed component:

      AssertionError: expected 'LocalizedConstructor' to equal 'Localized'
      + expected - actual

      -LocalizedConstructor
      +Localized

      at Context.<anonymous> (test/localize.js:27:47)
```

I think https://github.com/facebook/react/pull/7670 fixes the React change that caused the test to start failing (and thus it will stop failing when our dep is updated), but we should still make the test more solid.
