### PR TITLE
Redirect cli link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var translation = i18n.translate( 'Some content to translate' );
 
 ### Strings Only
 
-Translation strings are extracted from our codebase through a process of [static analysis](http://en.wikipedia.org/wiki/Static_program_analysis) and imported into GlotPress where they are translated ([more on that process here](../../../../server/i18n)). So you must avoid passing a variable, ternary expression, function call, or other form of logic in place of a string value to the `translate` method. The _one_ exception is that you can split a long string into mulitple substrings concatenated with the `+` operator.
+Translation strings are ewxtracted from our codebase through a process of [static analysis](http://en.wikipedia.org/wiki/Static_program_analysis) and imported into GlotPress where they are translated ([more on that process here](./cli)). So you must avoid passing a variable, ternary expression, function call, or other form of logic in place of a string value to the `translate` method. The _one_ exception is that you can split a long string into mulitple substrings concatenated with the `+` operator.
 
 ```js
 /*----------------- Bad Examples -----------------*/


### PR DESCRIPTION
This PR fixes a link that was broken when we broke the i18n-calypso out of calypso.

The README this linked to used to be more verbose ( you can see `server/i18n/README` [here](https://github.com/Automattic/wp-calypso/commit/8b22a277b418b7e473408f22776e18cae8dd28cd#diff-dd40dfac416932b9245faaa44fd950c4) ), but the purpose is to link to the parsing & json/pot generation aspect of the tool, which is now in the cli directory of this module.