### PR TITLE
Allow exposed composed component

### DIFF
--- a/lib/localize/index.js
+++ b/lib/localize/index.js
@@ -16,7 +16,7 @@ module.exports = function( i18n ) {
 	return function( ComposedComponent ) {
 		var componentName = ComposedComponent.displayName || ComposedComponent.name || '';
 
-		return React.createClass( {
+		var component = React.createClass( {
 			displayName: 'Localized' + componentName,
 
 			componentDidMount: function() {
@@ -37,5 +37,7 @@ module.exports = function( i18n ) {
 				return React.createElement( ComposedComponent, props );
 			}
 		} );
+		component._composedComponent = ComposedComponent;
+		return component;
 	};
 };


### PR DESCRIPTION
Sometimes it's necessary to call a function on a React instance during testing. But when `localize()` wraps the component, it's impossible to access to the actual component.

E.g.

```js
const MyComponent = React.createClass( {
  sayMyName() {
    var s = new SpeechSynthesisUtterance();
    s.text = 'Heisenberg';
    s.lang = 'en-US';
    speechSynthesis.speak( s );
  }
} );
export default localize( MyComponent );
```

and

```js
const = component = TestUtils.renderIntoDocument( <MyComponent { ...props } /> );
component.sayMyName();
```

Will throw.


