### PR TITLE
Change Localize HOC display name to be consistent with react-redux

### DIFF
--- a/lib/localize/index.js
+++ b/lib/localize/index.js
@@ -17,7 +17,7 @@ module.exports = function( i18n ) {
 		var componentName = ComposedComponent.displayName || ComposedComponent.name || '';
 
 		var component = React.createClass( {
-			displayName: 'Localized' + componentName,
+			displayName: 'Localized(' + componentName + ')',
 
 			componentDidMount: function() {
 				this.boundForceUpdate = this.forceUpdate.bind( this );

--- a/test/localize.js
+++ b/test/localize.js
@@ -22,7 +22,7 @@ describe( 'localize()', function() {
 
 		var LocalizedComponent = localize( MyComponent );
 
-		expect( LocalizedComponent.displayName ).to.equal( 'Localized' );
+		expect( LocalizedComponent.displayName ).to.equal( 'Localized()' );
 	} );
 
 	it( 'should be named using the displayName of the composed component', function() {
@@ -33,7 +33,7 @@ describe( 'localize()', function() {
 
 		var LocalizedComponent = localize( MyComponent );
 
-		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyComponent' );
+		expect( LocalizedComponent.displayName ).to.equal( 'Localized(MyComponent)' );
 	} );
 
 	it( 'should be named using the name of the composed function component', function() {
@@ -41,7 +41,7 @@ describe( 'localize()', function() {
 
 		var LocalizedComponent = localize( MyComponent );
 
-		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyComponent' );
+		expect( LocalizedComponent.displayName ).to.equal( 'Localized(MyComponent)' );
 	} );
 
 	it( 'should provide translate, moment, and numberFormat props to rendered child', function() {


### PR DESCRIPTION
The display name of Localize component is currently Localize+ComponentName which is not consistent with react-redux HOC connect which is Connect(ComponentName).

This convension makes it easier to identify Localize as HOC when using tools such as Rect Perf or Rect DevTools.