### PR TITLE
Update moment-timezone to latest available version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.7.2
+-----
+Update `moment-timezone` to version `0.5.11`. 
+
 1.7.1
 -----
 - Allow exposed composed component, see [#25](https://github.com/Automattic/i18n-calypso/pull/25).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {
@@ -30,7 +30,7 @@
     "lodash.assign": "^4.0.8",
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
-    "moment-timezone": "0.4.0",
+    "moment-timezone": "0.5.11",
     "react": "0.14.8 || ^15.1.0",
     "xgettext-js": "1.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -210,6 +210,12 @@ describe( 'I18n', function() {
 			it( 'should use available translations for relative time in the future', function() {
 				assert.equal( 'in ein paar Sekunden', moment().add( 10, 'seconds' ).fromNow() );
 			} );
+			it( 'should be able to convert dates to any timezone', function() {
+				assert.equal( 'Freitag, 18. Juli 2014 14:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'America/Los_Angeles' ).format( 'LLLL' ) );
+				assert.equal( 'Samstag, 19. Juli 2014 06:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'Asia/Tokyo' ).format( 'LLLL' ) );
+				assert.equal( 'Freitag, 18. Juli 2014 23:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'Europe/Paris' ).format( 'LLLL' ) );
+				assert.equal( 'Freitag, 18. Juli 2014 22:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'Europe/London' ).format( 'LLLL' ) );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request simply makes sure we use the latest version of the [`moment-timezone` module](https://www.npmjs.com/package/moment-timezone), i.e. version `0.5.11` (see the [changelog](https://github.com/moment/moment-timezone/blob/master/changelog.md) for the list of changes since version `0.4.0`).
 
#### Testing instructions
 
1. Run `git checkout update/moment-timezone`
2. Run `npm install`
3. Run `npm test` and check that no unit test fails