### PR TITLE
Bugfix: fix call stack exceeded by long line without seperators

### DIFF
--- a/cli/formatters/pot.js
+++ b/cli/formatters/pot.js
@@ -56,6 +56,11 @@ function multiline( literal, startAt ) {
 		}
 	}
 
+	// we encountered a line without separators, don't break it
+	if ( i === literal.length - 1 ) {
+		return literal;
+	}
+
 	return literal.substring( startAt, nextSpaceIndex + 1 ) + '"\n' + multiline( '"' + literal.substr( nextSpaceIndex + 1 ), 0 );
 }
 

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -128,6 +128,14 @@ describe( 'index', function() {
 					'"laborisnisiutaliquipexeacommodo consequat."'
 				].join( '\n' ) );
 			} );
+
+			it( 'should not break very long line without separators', function() {
+				var literal = '"LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequat."';
+				expect( multiline( literal ) ).to.equal( [
+					'""',
+					'"LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequat."'
+				].join( '\n' ) );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Currently, the program crashes when encountered a very long line without seperators.

For example, give this input:
```js
translate('LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequat.')
``` 

The recursive function [`#multiline`](https://github.com/Automattic/i18n-calypso/blob/master/cli/formatters/pot.js#L59) can't identify any seperator in this `literal`, so the recursion goes into a deeper and deeper level, and eventually results in call stack explosion :(

There are two kinds of solution to avoid this scenario:

1. force line breaks at the max position
2. just leave it as it is

I took the second solution, hope it may help others :)