### PR TITLE
Added support for input file patterns in the CLI script

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,7 +5,7 @@
  */
 var flatten = require( 'lodash.flatten' ),
 	fs = require( 'fs' ),
-	glob = require( 'glob' ),
+	globby = require( 'globby' ),
 	path = require( 'path' ),
 	program = require( 'commander' );
 
@@ -57,14 +57,7 @@ if ( inputFiles.length === 0 ) {
 	throw new Error( 'Error: You must enter the input file. Run `i18n-calypso -h` for examples.' );
 }
 
-if ( outputFile ) {
-	outputFile = path.resolve( process.env.PWD, outputFile );
-}
-
-// files relative to terminal location
-inputPaths = flatten( inputFiles.map( function( fileName ) {
-	return glob.sync( fileName, { cwd: process.env.PWD } );
-} ) );
+inputPaths = globby.sync( inputFiles );
 
 console.log( 'Reading inputFiles:\n\t- ' + inputPaths.join( '\n\t- ' ) );
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "^1.5.2",
     "commander": "^2.9.0",
     "debug": "2.2.0",
-    "glob": "^7.0.6",
+    "globby": "^6.1.0",
     "interpolate-components": "1.1.0",
     "jed": "1.0.2",
     "jstimezonedetect": "1.0.5",


### PR DESCRIPTION
It's already possible to use `glob` patterns ([node-glob](https://github.com/isaacs/node-glob)) to specify files to generate translations for, but that support was insufficient. As seen in the `wp-calypso` Makefile ([here](https://github.com/Automattic/wp-calypso/blob/master/Makefile#L195)), the command is being invoked with a list of plain paths (the result of a complex `find` command).

To remove that `find` command and use file patterns, we need to switch to [globby](https://github.com/sindresorhus/globby), a more advanced version of `glob` that supports negative patterns, like this:
`i18n-calypso **/*.js **/*.jsx !excluded_dir/**`

I also removed references to `process.env.PWD` since they don't work on Windows. Does it matter to use `process.cwd()` instead? (Which is used by default). I haven't found any difference testing it locally.