### PR TITLE
Handle options with new plural syntax

### DIFF
--- a/cli/preprocess-xgettextjs-match.js
+++ b/cli/preprocess-xgettextjs-match.js
@@ -21,7 +21,7 @@ module.exports = function preProcessXGettextJSMatch( match ) {
 
 	args = match.arguments;
 
-	[ 'single', 'plural' ].slice( 0, args.length ).forEach( function( field, i ) {
+	[ 'single', 'plural', 'options' ].slice( 0, args.length ).forEach( function( field, i ) {
 		if ( 'StringLiteral' === args[i].type ) {
 			finalProps[field] = makeDoubleQuoted( args[i].extra.raw );
 		} else if ( 'BinaryExpression' === args[i].type ) {

--- a/test/cli/examples/i18n-test-examples.jsx
+++ b/test/cli/examples/i18n-test-examples.jsx
@@ -76,6 +76,11 @@ corners.` );
 	i18n.translate( 'My hat has three corners.', {
 		'comment': 'Second ocurrence'
 	} );
+
+	i18n.translate( 'My hat has one corner.', 'My hat has many corners.', {
+		context: 'context after new plural syntax',
+		count: 5
+	} );
 }
 
 module.exports = test;

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -219,6 +219,10 @@ describe( 'index', function() {
 			expect( output ).to.have.string( 'msgctxt "context with a literal string key"\nmsgid "The string key text"\nmsgstr ""\n' );
 		} );
 
+		it( 'should find options with new plural syntax', function() {
+			expect( output ).to.have.string( 'msgctxt "context after new plural syntax"\nmsgid "My hat has one corner."\nmsgid_plural "My hat has many corners."\nmsgstr[0] ""\n' );
+		} );
+
 		it( 'should handle template literals', function() {
 			expect( output ).to.have.string( 'msgid "My hat has six corners."' );
 			expect( output ).to.have.string( 'msgid "My hat\\nhas seventeen\\ncorners."' );


### PR DESCRIPTION
This prevents the options object from being ignored with the "new" plural syntax.
Example string:

```
this.translate(
				'Registering this domain for a company? + Add Organization Name',
				'Registering these domains for a company? + Add Organization Name',
				{
					context: 'Domain contact information page',
					comment: 'Count specifies the number of domain registrations',
					count: 5
				}
```

Without this patch, the context and comment are ignored in the output.
