### PR TITLE
Merge locale data with existing one when we're not switching locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following attributes can be set in the options object to alter the translati
 If you pass a single string into `translate`, it will trigger a simple translation without any context, pluralization, sprintf arguments, or comments. You would call it like this.
 
 ```js
-var i18n = require( 'i18n' );
+var i18n = require( 'i18n-calypso' );
 var translation = i18n.translate( 'Some content to translate' );
 ```
 
@@ -224,7 +224,7 @@ var thisMagicMoment = i18n.moment( "2014-07-18T14:59:09-07:00" ).format( 'LLLL' 
 And you can use it from outside of React like this.
 
 ```js
-var i18n = require( 'i18n' );
+var i18n = require( 'i18n-calypso' );
 var thisMagicMoment = i18n.moment( "2014-07-18T14:59:09-07:00" ).format( 'LLLL' );
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -167,30 +167,30 @@ I18N.prototype.configure = function( options ) {
 };
 
 I18N.prototype.setLocale = function( localeData ) {
-	var localeSlug;
-
-	// if localeData is not given, assumes default locale
+	// if localeData is not given, assumes default locale and reset
 	if ( ! localeData || ! localeData[ '' ].localeSlug ) {
-		localeData = { '': { localeSlug: this.defaultLocaleSlug } }
+		this.state.locale = { '': { localeSlug: this.defaultLocaleSlug } };
+	} else if ( localeData[ '' ].localeSlug === this.state.localeSlug ) {
+		// Exit if same data as current (comparing references only)
+		if ( localeData === this.state.locale ) {
+			return;
+		}
+
+		// merge new data into existing one
+		assign( this.state.locale, localeData );
+	} else {
+		this.state.locale = assign( {}, localeData );
 	}
 
-	localeSlug = localeData[ '' ].localeSlug;
-
-	// Don't change if same locale as current, except for default locale
-	if ( localeSlug !== this.defaultLocaleSlug && localeSlug === this.state.localeSlug ) {
-		return;
-	}
-
-	this.state.localeSlug = localeSlug;
-	this.state.locale = localeData;
+	this.state.localeSlug = this.state.locale[ '' ].localeSlug;
 
 	this.state.jed = new Jed( {
 		locale_data: {
-			messages: localeData
+			messages: this.state.locale
 		}
 	} );
 
-	moment.locale( localeSlug );
+	moment.locale( this.state.localeSlug );
 
 	// Updates numberFormat preferences with settings from translations
 	this.state.numberFormatSettings.decimal_point = getTranslationFromJed(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -2,13 +2,13 @@
 var locale = {
 	'': {
 		localeSlug: 'de',
-		'Plural-Forms': ' nplurals=2; plural=n != 1;',
-		'MIME-Version': ' 1.0',
-		'X-Generator': ' GlotPress/0.1',
-		'Content-Type': ' text/plain; charset=UTF-8',
-		'PO-Revision-Date': ' 2014-08-11 23:50:52+0000',
-		'Content-Transfer-Encoding': ' 8bit',
-		'Project-Id-Version': ' WordPress.com'
+		'Plural-Forms': 'nplurals=2; plural=n != 1;',
+		'MIME-Version': '1.0',
+		'X-Generator': 'GlotPress/0.1',
+		'Content-Type': 'text/plain; charset=UTF-8',
+		'PO-Revision-Date': '2014-08-11 23:50:52+0000',
+		'Content-Transfer-Encoding': '8bit',
+		'Project-Id-Version': 'WordPress.com'
 	},
 	'test1': [
 		null,

--- a/test/index.js
+++ b/test/index.js
@@ -28,13 +28,79 @@ function stripReactAttributes( string ) {
 describe( 'I18n', function() {
 	useFakeDom();
 
-	before( function() {
+	beforeEach( function() {
 		i18n.setLocale( data.locale );
-		moment.locale( 'de' );
 	} );
 
-	after( () => {
-		moment.locale( 'en' );
+	afterEach( function() {
+		i18n.configure(); // ensure everything is reset
+	} );
+
+	describe( 'setLocale()', function() {
+		describe( 'adding a new locale source from the same language', function () {
+			beforeEach( function() {
+				i18n.setLocale( {
+					'': data.locale[''],
+					'test1': [
+						null,
+						'translation1-1'
+					],
+					'test2': [
+						null,
+						'translation2'
+					],
+					'new translation': [
+						null,
+						'Neue Übersetzung'
+					]
+				} );
+			} );
+
+			it( 'should make the new translations available', function () {
+				assert.equal( 'Neue Übersetzung', translate( 'new translation' ) );
+			} );
+			it( 'should keep the original translations available as well', function () {
+				assert.equal( 'Aktivieren', translate( 'Activate' ) );
+			} );
+			it( 'should replace existing translations with the new version', function () {
+				assert.equal( 'translation1-1', translate( 'test1' ) );
+				assert.equal( 'translation2', translate( 'test2' ) );
+			} );
+		} );
+
+		describe( 'adding a new locale source from a different language', function () {
+			beforeEach( function() {
+				i18n.setLocale( {
+					'': Object.assign( {}, data.locale[''], {
+						localeSlug: 'fr',
+						'Plural-Forms': 'nplurals=2; plural=n > 1;'
+					} ),
+					'test1': [
+						null,
+						'traduction1'
+					],
+					'test2': [
+						null,
+						'traduction2'
+					],
+					'new translation': [
+						null,
+						'nouvelle traduction'
+					]
+				} );
+			} );
+
+			it( 'should make replace previous locale translations', function () {
+				assert.notEqual( 'translation1', translate( 'test1' ) );
+				assert.equal( 'traduction1', translate( 'test1' ) );
+			} );
+			it( 'should make old translations unavailable', function () {
+				assert.equal( 'Activate', translate( 'Activate' ) );
+			} );
+			it( 'should make new translations available', function () {
+				assert.equal( 'nouvelle traduction', translate( 'new translation' ) );
+			} );
+		} );
 	} );
 
 	describe( 'translate()', function() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/i18n-calypso/issues/39

This patch allows `i18n.setLocale()` to add new translations to the set of existing ones if the locale is not changed.

### Testing Instructions
- Apply patch locally and [link](https://docs.npmjs.com/cli/link) `i18n-calypso` to your local directory
- Run `wp-calypso` locally with `npm start` and load localized page. Check that both https://widgets.wp.com/languages/notifications/fr.json and https://widgets.wp.com/languages/calypso/fr.json are now used

### Reviews
- [x] Code
- [x] Product
- [x] Tests

Note: also fixes https://github.com/Automattic/i18n-calypso/issues/27
