### PR TITLE
Fix improperly escaped control sequence in POT files

### DIFF
--- a/cli/preprocess-xgettextjs-match.js
+++ b/cli/preprocess-xgettextjs-match.js
@@ -101,7 +101,7 @@ function makeDoubleQuoted( literal ) {
 
 	// double-quoted string
 	if ( literal.charAt( 0 ) === '"' ) {
-		return literal;
+		return literal.replace( /(\\)/g, '\\$1' );
 	}
 
 	// single-quoted string

--- a/test/cli/examples/i18n-test-examples.jsx
+++ b/test/cli/examples/i18n-test-examples.jsx
@@ -81,6 +81,22 @@ corners.` );
 		context: 'context after new plural syntax',
 		count: 5
 	} );
+	i18n.translate( 'This is how the test performed\u2026' );
+
+	i18n.translate(
+		"It's been %(timeLapsed)s since {{href}}{{postTitle/}}{{/href}} was published. Here's how the post has performed so far\u2026",
+		{
+			args: {
+				timeLapsed: postTime.fromNow( true ),
+			},
+			components: {
+				href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
+				postTitle: <Emojify>{ postTitle }</Emojify>,
+			},
+			context:
+				'Stats: Sentence showing how much time has passed since the last post, and how the stats are',
+		}
+	);
 }
 
 module.exports = test;

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -235,6 +235,11 @@ describe( 'index', function() {
 			expect( output ).to.have.string( 'msgid "My hat has six corners."' );
 			expect( output ).to.have.string( 'msgid "My hat\\nhas seventeen\\ncorners."' );
 		} );
+
+		it( 'should properly handle unicode escapes', function() {
+			expect( output ).to.have.string( "This is how the test performed\\\\u2026" );
+			expect( output ).to.have.string( "Here's how the post has performed so far\\\\u2026" );
+		} );
 	} );
 
 	describe( 'PHP', function() {


### PR DESCRIPTION
A string like
```
i18n.translate( "This is how the test performed\u2026" );
```
would arrive in the POT file as 
```
msgid "This is how the test performed\u2026"
msgstr ""
```
Leading to an error message by `msgcat` like:
```
calypso-strings.pot:2:54: invalid control sequence
```

while the `\` should be escaped. This PR fixes this.