### PR TITLE
Remove react-addons-test-utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "chai": "^3.5.0",
     "enzyme": "2.2.0",
     "mocha": "^2.4.5",
-    "react-addons-test-utils": "0.14.8 || ^15.1.0",
     "react-dom": "0.14.8 || ^15.1.0",
     "react-test-env": "0.1.1",
     "rewire": "^2.5.1"

--- a/package.json
+++ b/package.json
@@ -31,15 +31,16 @@
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
     "moment-timezone": "0.5.11",
-    "react": "0.14.8 || ^15.1.0",
+    "react": "0.14.8 || ^15.5.0",
     "xgettext-js": "1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "enzyme": "2.2.0",
+    "enzyme": "2.9.1",
     "mocha": "^2.4.5",
-    "react-dom": "0.14.8 || ^15.1.0",
+    "react-dom": "0.14.8 || ^15.5.0",
     "react-test-env": "0.1.1",
+    "react-test-renderer": "^15.5.0",
     "rewire": "^2.5.1"
   }
 }


### PR DESCRIPTION
To test: Verify that this isn't actually used anywhere in the code.

Relevant for https://github.com/Automattic/wp-calypso/pull/19083