### PR TITLE
createClass --> es6 class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.8.2
+------
+Change localize hoc's React.createClass --> es6 classes for React 16 compat.
+
 1.8.1
 -----
 Fix a control sequence escaping error in POT files, see [#41](https://github.com/Automattic/i18n-calypso/pull/41).

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,4 @@
+machine:
+  node:
+    version: v6.1.0
+

--- a/lib/localize/index.js
+++ b/lib/localize/index.js
@@ -16,7 +16,7 @@ module.exports = function( i18n ) {
 	return function( ComposedComponent ) {
 		var componentName = ComposedComponent.displayName || ComposedComponent.name || '';
 
-		var component = class extends React.Component {
+		class component extends React.Component {
 			componentDidMount() {
 				this.boundForceUpdate = this.forceUpdate.bind( this );
 				i18n.stateObserver.addListener( 'change', this.boundForceUpdate );

--- a/lib/localize/index.js
+++ b/lib/localize/index.js
@@ -16,28 +16,27 @@ module.exports = function( i18n ) {
 	return function( ComposedComponent ) {
 		var componentName = ComposedComponent.displayName || ComposedComponent.name || '';
 
-		var component = React.createClass( {
-			displayName: 'Localized(' + componentName + ')',
-
-			componentDidMount: function() {
+		var component = class extends React.Component {
+			componentDidMount() {
 				this.boundForceUpdate = this.forceUpdate.bind( this );
 				i18n.stateObserver.addListener( 'change', this.boundForceUpdate );
-			},
+			}
 
-			componentWillUnmount: function() {
+			componentWillUnmount() {
 				// in some cases, componentWillUnmount is called before componentDidMount
 				// Supposedly fixed in React 15.1.0: https://github.com/facebook/react/issues/2410
 				if ( this.boundForceUpdate ) {
 					i18n.stateObserver.removeListener( 'change', this.boundForceUpdate );
 				}
-			},
+			}
 
-			render: function() {
+			render() {
 				var props = assign( {}, this.props, i18nProps );
 				return React.createElement( ComposedComponent, props );
 			}
-		} );
+		}
 		component._composedComponent = ComposedComponent;
+		component.displayName = 'Localized(' + componentName + ')'
 		return component;
 	};
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "^3.5.0",
     "enzyme": "2.9.1",
     "mocha": "^2.4.5",
-    "react-dom": "0.14.8 || ^15.5.0",
+    "react-dom": "0.14.8 || ^15.5.0 || ^16.0.0",
     "react-test-env": "0.1.1",
     "react-test-renderer": "^15.5.0",
     "rewire": "^2.5.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
     "moment-timezone": "0.5.11",
-    "react": "0.14.8 || ^15.5.0",
+    "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "xgettext-js": "1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/test/localize.js
+++ b/test/localize.js
@@ -16,20 +16,20 @@ describe( 'localize()', function() {
 	useFakeDom();
 
 	it( 'should be named using the variable name of the composed component', function() {
-		var MyComponent = React.createClass( {
-			render: emptyRender
-		} );
+		class MyComponent extends React.Component {
+			render() {
+				return emptyRender();
+			}
+		}
 
 		var LocalizedComponent = localize( MyComponent );
 
-		expect( LocalizedComponent.displayName ).to.equal( 'Localized()' );
+		expect( LocalizedComponent.displayName ).to.equal( 'Localized(MyComponent)' );
 	} );
 
 	it( 'should be named using the displayName of the composed component', function() {
-		var MyComponent = React.createClass( {
-			displayName: 'MyComponent',
-			render: emptyRender
-		} );
+		var MyComponent = () => emptyRender();
+		MyComponent.displayName = 'MyComponent';
 
 		var LocalizedComponent = localize( MyComponent );
 
@@ -45,9 +45,7 @@ describe( 'localize()', function() {
 	} );
 
 	it( 'should provide translate, moment, and numberFormat props to rendered child', function() {
-		var MyComponent = React.createClass( {
-			render: emptyRender
-		} );
+		var MyComponent = () => emptyRender();
 		var LocalizedComponent = localize( MyComponent );
 
 		var mounted = mount( React.createElement( LocalizedComponent ) );


### PR DESCRIPTION
The reason for this PR is to unblock wp-calypso from [upgrading to React 16](https://github.com/Automattic/wp-calypso/pull/19083)
This PR introduces a few changes:
1. removes usage of `React.createClass` from the HoC localize func and also from the HoC tests
2. update peer dep to allow React 16
3. bump minor version. this should be fully back-compat


Thoughts on next steps:
1. release a `v2.0.0` with the mixin removed