### PR TITLE
Use react-create-class for es5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.8.3
+------
+Change localize hoc's es6 class --> [create-react-class](https://www.npmjs.com/package/create-react-class) so that the code is still technically es5 and will not need a build step.
+
 1.8.2
 ------
 Change localize hoc's React.createClass --> es6 classes for React 16 compat.

--- a/lib/localize/index.js
+++ b/lib/localize/index.js
@@ -1,5 +1,6 @@
 var React = require( 'react' ),
-	assign = require( 'lodash.assign' );
+	assign = require( 'lodash.assign' ),
+	createClass = require( 'create-react-class' );
 
 /**
  * Localize a React component
@@ -16,27 +17,28 @@ module.exports = function( i18n ) {
 	return function( ComposedComponent ) {
 		var componentName = ComposedComponent.displayName || ComposedComponent.name || '';
 
-		class component extends React.Component {
-			componentDidMount() {
+		var component = createClass({
+			displayName: 'Localized(' + componentName + ')',
+
+			componentDidMount: function() {
 				this.boundForceUpdate = this.forceUpdate.bind( this );
 				i18n.stateObserver.addListener( 'change', this.boundForceUpdate );
-			}
+			},
 
-			componentWillUnmount() {
+			componentWillUnmount: function() {
 				// in some cases, componentWillUnmount is called before componentDidMount
 				// Supposedly fixed in React 15.1.0: https://github.com/facebook/react/issues/2410
 				if ( this.boundForceUpdate ) {
 					i18n.stateObserver.removeListener( 'change', this.boundForceUpdate );
 				}
-			}
+			},
 
-			render() {
+			render: function() {
 				var props = assign( {}, this.props, i18nProps );
 				return React.createElement( ComposedComponent, props );
 			}
-		}
+		} );
 		component._composedComponent = ComposedComponent;
-		component.displayName = 'Localized(' + componentName + ')'
 		return component;
 	};
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
     "moment-timezone": "0.5.11",
+    "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "xgettext-js": "1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "enzyme": "2.9.1",
     "mocha": "^2.4.5",
-    "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "react-dom": "0.14.8 || ^15.5.0 || ^16.0.0",
     "react-test-env": "0.1.1",
     "react-test-renderer": "^15.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "commander": "^2.9.0",
+    "create-react-class": "^15.6.2",
     "debug": "2.2.0",
     "globby": "^6.1.0",
     "interpolate-components": "1.1.0",
@@ -31,13 +32,13 @@
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
     "moment-timezone": "0.5.11",
-    "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "xgettext-js": "1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "enzyme": "2.9.1",
     "mocha": "^2.4.5",
+    "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "react-dom": "0.14.8 || ^15.5.0 || ^16.0.0",
     "react-test-env": "0.1.1",
     "react-test-renderer": "^15.5.0",


### PR DESCRIPTION
This PR makes it so that `i18n-calypso` can be used without any transpilation. `class` was introduced in https://github.com/Automattic/i18n-calypso/pull/43  which would mean the consumer would need to compile the js if targeting platforms below es6.


This pull request maintains compatibility with React 16 and below by use `create-react-class` instead of React.createClass or es6 class.

The other two solutions considered were:
1. es5 classes
2. build step within `i18n-calypso`

To Test
-----
1. go to `wp-calypso` 
2. run: `npm install Automattic/i18n-calypso#fix/es5-compat` to install this branch
3. run `CALYPSO_ENV=production NODE_ENV=production npm run build` and ensure minification succeeds