### PR TITLE
Bump `interpolate-components` to 1.1.1 (for React 16 compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.8.4
+------
+Bump `interpolate-components` to 1.1.1 (for React 16 compat).
+
 1.8.3
 ------
 Change localize hoc's es6 class --> [create-react-class](https://www.npmjs.com/package/create-react-class) so that the code is still technically es5 and will not need a build step.
@@ -24,7 +28,7 @@ Improve input file pattern support, see [#25](https://github.com/Automattic/i18n
 
 1.7.2
 -----
-Update `moment-timezone` to version `0.5.11`. 
+Update `moment-timezone` to version `0.5.11`.
 
 1.7.1
 -----

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "create-react-class": "^15.6.2",
     "debug": "2.2.0",
     "globby": "^6.1.0",
-    "interpolate-components": "1.1.0",
+    "interpolate-components": "1.1.1",
     "jed": "1.0.2",
     "jstimezonedetect": "1.0.5",
     "lodash.assign": "^4.0.8",


### PR DESCRIPTION
Also bump version, Changelog

See https://github.com/Automattic/interpolate-components/pull/12.


To Test
------