### PR TITLE
Fix tests for 1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.8.5
+------
+Allow newer versions of xgettext-js [#46](https://github.com/Automattic/i18n-calypso/pull/46).
+
 1.8.4
 ------
 Bump `interpolate-components` to 1.1.1 (for React 16 compat).

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "enzyme": "^3.2.0",
-    "enzyme-adapter-react-14": "^1.0.5",
-    "enzyme-adapter-react-15.4": "^1.0.5",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-adapter-react-helper": "^1.2.3",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {
@@ -37,11 +37,15 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "enzyme": "2.9.1",
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-14": "^1.0.5",
+    "enzyme-adapter-react-15.4": "^1.0.5",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-adapter-react-helper": "^1.2.3",
     "mocha": "^2.4.5",
     "react-dom": "0.14.8 || ^15.5.0 || ^16.0.0",
     "react-test-env": "0.1.1",
-    "react-test-renderer": "^15.5.0",
+    "react-test-renderer": "^15.5.0 || ^16.0.0",
     "rewire": "^2.5.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -221,7 +221,7 @@ describe( 'I18n', function() {
 
 		describe( 'with mixed components', function() {
 			it( 'should handle sprintf and component interpolation together', function() {
-				var input = React.DOM.input(),
+				var input = React.createElement( 'input' ),
 					expectedResultString = '<span>foo <input/> bar</span>',
 					placeholder = 'bar',
 					translatedComponent = translate( 'foo {{ input /}} %(placeholder)s', {

--- a/test/localize.js
+++ b/test/localize.js
@@ -4,7 +4,7 @@
 var React = require( 'react' ),
 	setupEnzymeAdapter = require( 'enzyme-adapter-react-helper' ),
 	expect = require( 'chai' ).expect,
-	mount = require( 'enzyme' ).mount,
+	shallow = require( 'enzyme' ).shallow,
 	useFakeDom = require( 'react-test-env' ).useFakeDom;
 
 /**
@@ -50,7 +50,7 @@ describe( 'localize()', function() {
 		var MyComponent = () => emptyRender();
 		var LocalizedComponent = localize( MyComponent );
 
-		var mounted = mount( React.createElement( LocalizedComponent ) );
+		var mounted = shallow( React.createElement( LocalizedComponent ) );
 		var props = mounted.find( MyComponent ).props();
 
 		expect( props.translate ).to.be.a( 'function' );

--- a/test/localize.js
+++ b/test/localize.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	setupEnzymeAdapter = require( 'enzyme-adapter-react-helper' ),
 	expect = require( 'chai' ).expect,
 	mount = require( 'enzyme' ).mount,
 	useFakeDom = require( 'react-test-env' ).useFakeDom;
@@ -14,6 +15,7 @@ var localize = require( '..' ).localize,
 
 describe( 'localize()', function() {
 	useFakeDom();
+	setupEnzymeAdapter();
 
 	it( 'should be named using the variable name of the composed component', function() {
 		class MyComponent extends React.Component {

--- a/test/mixin.js
+++ b/test/mixin.js
@@ -3,7 +3,6 @@
  */
 var React = require( 'react' ),
 	createReactClass = require( 'create-react-class' ),
-	setupEnzymeAdapter = require( 'enzyme-adapter-react-helper' ),
 	expect = require( 'chai' ).expect,
 	shallow = require( 'enzyme' ).shallow,
 	render = require( 'enzyme' ).render,
@@ -18,7 +17,6 @@ var i18n = require( '..' ),
 
 describe( 'mixin()', function() {
 	useFakeDom();
-	setupEnzymeAdapter();
 
 	it( 'should add its properties to a React Component', function() {
 		var mixinComponent = createReactClass( {

--- a/test/mixin.js
+++ b/test/mixin.js
@@ -5,7 +5,7 @@ var React = require( 'react' ),
 	createReactClass = require( 'create-react-class' ),
 	setupEnzymeAdapter = require( 'enzyme-adapter-react-helper' ),
 	expect = require( 'chai' ).expect,
-	mount = require( 'enzyme' ).mount,
+	shallow = require( 'enzyme' ).shallow,
 	render = require( 'enzyme' ).render,
 	useFakeDom = require( 'react-test-env' ).useFakeDom;
 
@@ -26,7 +26,7 @@ describe( 'mixin()', function() {
 			render: emptyRender
 		} );
 
-		var mounted = mount( React.createElement( mixinComponent ) );
+		var mounted = shallow( React.createElement( mixinComponent ) );
 
 		expect( mounted.instance().translate ).to.be.a( 'function' );
 		expect( mounted.instance().moment ).to.be.a( 'function' );

--- a/test/mixin.js
+++ b/test/mixin.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	createReactClass = require( 'create-react-class' ),
+	setupEnzymeAdapter = require( 'enzyme-adapter-react-helper' ),
 	expect = require( 'chai' ).expect,
 	mount = require( 'enzyme' ).mount,
 	render = require( 'enzyme' ).render,
@@ -16,18 +18,19 @@ var i18n = require( '..' ),
 
 describe( 'mixin()', function() {
 	useFakeDom();
+	setupEnzymeAdapter();
 
 	it( 'should add its properties to a React Component', function() {
-		var mixinComponent = React.createClass( {
+		var mixinComponent = createReactClass( {
 			mixins: [ i18nMixin ],
 			render: emptyRender
 		} );
 
 		var mounted = mount( React.createElement( mixinComponent ) );
 
-		expect( mounted.node.translate ).to.be.a( 'function' );
-		expect( mounted.node.moment ).to.be.a( 'function' );
-		expect( mounted.node.numberFormat ).to.be.a( 'function' );
+		expect( mounted.instance().translate ).to.be.a( 'function' );
+		expect( mounted.instance().moment ).to.be.a( 'function' );
+		expect( mounted.instance().numberFormat ).to.be.a( 'function' );
 	} );
 
 	it( 'should be able to translate a string inside render', function() {
@@ -41,7 +44,7 @@ describe( 'mixin()', function() {
 			]
 		} );
 
-		var mixinComponent = React.createClass( {
+		var mixinComponent = createReactClass( {
 			mixins: [ i18nMixin ],
 			render: function() {
 				return React.createElement( 'p', null, this.translate( 'hello' ) );


### PR DESCRIPTION
While preparing 1.8.5 (to include #46), I've discovered a number of failing tests. Could you please verify that my fixes are ok?

Most changes were required by the `enzyme` upgrade, which was in turn caused by this error message:
```
/home/ubuntu/i18n-calypso/node_modules/enzyme/build/react-compat.js:144
      throw new Error('react-addons-test-utils is an implicit dependency in order to support react@0.13-14. ' + 'Please add the appropriate version to your devDependencies. ' + 'See https://github.com/airbnb/enzyme#installation');
```

The tricky thing here is that with `i18n-calypso` we want don't want to cut off older React versions, hence the `enzyme-adapter-react-helper` dance.