### PR TITLE
Add support for key hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.9.0
+------
+Add support for [key hashing](https://github.com/Automattic/i18n-calypso/#key-hashing) and add a method [`hasTranslation()`](https://github.com/Automattic/i18n-calypso/#hastranslation-method).
+
 1.8.5
 ------
 Allow newer versions of xgettext-js [#46](https://github.com/Automattic/i18n-calypso/pull/46).

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ I18n accepts a language-specific locale json file that contains the whitelisted 
 
 ### Key Hashing
 
-In order to reduce file-size, i18n-calypso allows the usage of hashed keys for lookup. This is a non-standard extension of the Jed standard which is enabled by supplying a header key `key-hash` to specify a hash method (currently only `sha1` is supported), as well as a hash length. For example `sha1-4` uses the first 4 hexadecimal chars of the sha1 hash of the standard Jed lookup string.
+In order to reduce file-size, i18n-calypso allows the usage of hashed keys for lookup. This is a non-standard extension of the Jed standard which is enabled by supplying a header key `key-hash` to specify a hash method (currently only `sha1` is supported), as well as a hash length. For example `sha1-4` uses the first 4 hexadecimal chars of the sha1 hash of the standard Jed lookup string. As a further optimization, variable hash lengths are available, potentially requiring multiple lookups per string: `sha1-3-7` specifies that hash lengths of 3 to 7 are used in the file.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This lib enables translations, exposing three public methods:
 * [.moment()](#moment-method)
 * [.numberFormat()](#numberformat-method)
 
-It also provides 2 utility methods for your React application:
+It also provides three utility methods for your React application:
 
 * [.mixin](#mixin)
 * [.localize()](#localize)
-
+* [.hasTranslation()](#hastranslation-method)
 
 ## Translate Method
 
@@ -242,12 +242,22 @@ i18n.numberFormat( 2500.1, 2 ); // '2.500,10'
 i18n.numberFormat( 2500.33, { decimals: 3, thousandsSep: '*', decPoint: '@'} ); // '2*500@330'
 ```
 
+## hasTranslation Method
+
+Using the method `hasTranslation` you can check whether a translation for a given string exists. As the `translate()` function will always return screen text that can be displayed (will supply the source text if no translation exists), it is unsuitable to determine whether text is translated. Other factors are optional [key hashing](#key-hashing) as well as purposeful translation to the source text.
+
+### Usage
+```js
+var i18n = require( 'i18n-calypso' );
+i18n.hasTranslation( 'This has been translated' ); // true
+i18n.hasTranslation( 'Not translation exists' ); // false
+```
 
 ## Mixin
 
 ### Usage
 
-```js
+```jsx
 import { mixin as i18nMixin } from 'i18n-calypso';
 
 const MyComponent = React.createClass( {
@@ -321,5 +331,23 @@ render(
 
 ## Some Background
 
-I18n accepts a language-specific locale json file that contains the whitelisted translation strings for your JS project, uses that data to instantiate a [Jed](http://slexaxton.github.io/Jed/) instance, and exposes a single `translate` method with sugared syntax for interacting with Jed.
+I18n accepts a language-specific locale json file that contains the whitelisted translation strings for your JS project, uses that data to instantiate a [Jed](https://messageformat.github.io/Jed/) instance, and exposes a single `translate` method with sugared syntax for interacting with Jed.
+
+### Key Hashing
+
+In order to reduce file-size, i18n-calypso allows the usage of hashed keys for lookup. This is a non-standard extension of the Jed standard which is enabled by supplying a header key `key-hash` to specify a hash method (currently only `sha1` is supported), as well as a hash length. For example `sha1-4` uses the first 4 hexadecimal chars of the sha1 hash of the standard Jed lookup string.
+
+#### Example
+
+Instead of providing the full English text, like here:
+```json
+{"":{"localeSlug":"de"},"Please enter a valid email address.":["","Bitte gib eine gültige E-Mail-Adresse ein."]}
+```
+just the hash is used for lookup, resulting in a shorter file.
+```json
+{"":{"localeSlug":"de","key-hash":"sha1-1"},"d":["","Bitte gib eine gültige E-Mail-Adresse ein."]}
+```
+The generator of the jed file would usually try to choose the smallest hash length at which no hash collisions occur. In the above example a hash length of 1 (`d` short for `d2306dd8970ff616631a3501791297f31475e416`) is enough because there is only one string.
+
+Note that when generating the jed file, all possible strings need to be taken into consideration for the collision calculation, as otherwise an untranslated source string would be provided with the wrong translation.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,8 @@ var translationLookup = [
 	}
 ];
 
+var hashCache = {};
+
 // raise a console warning
 function warn() {
 	if ( ! I18N.throwErrors ) {
@@ -190,33 +192,51 @@ I18N.prototype.configure = function( options ) {
 
 I18N.prototype.setLocale = function( localeData ) {
 	if ( localeData && localeData[ '' ] && localeData[ '' ][ 'key-hash' ] ) {
-		var transform, hashLength, keyHash = localeData[ '' ][ 'key-hash' ];
+		var hashLength, minHashLength, maxHashLength, keyHash = localeData[ '' ][ 'key-hash' ];
 
-		if ( keyHash.substr( 0, 4 ) === 'sha1' ) {
-			hashLength = Number ( keyHash.substr( 5 ) );
+		var transform = function( string, hashLength ) {
+			if ( typeof hashCache[ hashLength + string ] !== 'undefined' ) {
+				return hashCache[ hashLength + string ];
+			}
+			var hash = sha1( string );
 
-			transform = function( string ) {
-				var hash = sha1( string );
+			if ( hashLength ) {
+				return hashCache[ hashLength + string ] = hash.substr( 0, hashLength );
+			}
 
-				if ( hashLength ) {
-					return hash.substr( 0, hashLength );
-				}
+			return hashCache[ hashLength + string ] = hash;
+		};
 
-				return hash;
-			};
-		}
-
-		if ( transform ) {
-			translationLookup.push( function( options ) {
+		var generateLookup = function( hashLength ) {
+			return function( options ) {
 				if ( options.context ) {
-					options.original = transform( options.context + String.fromCharCode( 4 ) + options.original );
+					options.original = transform( options.context + String.fromCharCode( 4 ) + options.original, hashLength );
 					delete options.context;
 				} else {
-					options.original = transform( options.original );
+					options.original = transform( options.original, hashLength );
 				}
 
 				return options;
-			} );
+			};
+		}
+
+		if ( keyHash.substr( 0, 4 ) === 'sha1' ) {
+			if ( keyHash.length === 4 ) {
+				translationLookup.push( generateLookup( false ) );
+			} else {
+				var variableHashLengthPos = keyHash.substr( 5 ).indexOf( '-' );
+				if ( variableHashLengthPos < 0 ) {
+					hashLength = Number( keyHash.substr( 5 ) );
+					translationLookup.push( generateLookup( hashLength ) );
+				} else {
+					minHashLength = Number( keyHash.substr( 5, variableHashLengthPos ) );
+					maxHashLength = Number( keyHash.substr( 6 + variableHashLengthPos ) );
+
+					for ( hashLength = minHashLength; hashLength <= maxHashLength; hashLength++ ) {
+						translationLookup.push( generateLookup( hashLength ) );
+					}
+				}
+			}
 		}
 	}
 
@@ -297,10 +317,11 @@ I18N.prototype.addTranslations = function( localeData ) {
 
 
 /**
- * Checks whether the given original has a translation.
+ * Checks whether the given original has a translation. Parameters are the same as for translate().
  *
- * @param  {string} original  - the string to translate
- * @param  {string} plural  - the plural string to translate (if applicable), original used as singular
+ * @param  {string} original  the string to translate
+ * @param  {string} plural    the plural string to translate (if applicable), original used as singular
+ * @param  {object} options   properties describing translation requirements for given text
  * @return {boolean} whether a translation exists
  */
 I18N.prototype.hasTranslation = function() {
@@ -310,13 +331,13 @@ I18N.prototype.hasTranslation = function() {
 /**
  * Exposes single translation method, which is converted into its respective Jed method.
  * See sibling README
- * @param  {string} original  - the string to translate
- * @param  {string} plural  - the plural string to translate (if applicable), original used as singular
- * @param  {object} options - properties describing translation requirements for given text
+ * @param  {string} original  the string to translate
+ * @param  {string} plural    the plural string to translate (if applicable), original used as singular
+ * @param  {object} options   properties describing translation requirements for given text
  * @return {string|React-components} translated text or an object containing React children that can be inserted into a parent component
  */
 I18N.prototype.translate = function() {
-	var options, optionsString, translation, sprintfArgs, errorMethod, cacheable, i;
+	var options, translation, sprintfArgs, errorMethod, optionsString, cacheable;
 
 	options = normalizeTranslateArguments( arguments );
 
@@ -332,7 +353,8 @@ I18N.prototype.translate = function() {
 
 	translation = getTranslation( this, options );
 	if ( ! translation ) {
-		// In this case we need jed to give us an object with English text.
+		// This purposefully calls jed for a case where there is no translation,
+		// so that jed gives us the expected object with English text.
 		translation = getTranslationFromJed( this.state.jed, options );
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@
 var debug = require( 'debug' )( 'i18n-calypso' ),
 	Jed = require( 'jed' ),
 	moment = require( 'moment-timezone' ),
+	sha1 = require( 'sha1' ),
 	EventEmitter = require( 'events' ).EventEmitter,
 	interpolateComponents = require( 'interpolate-components' ).default,
 	LRU = require( 'lru' ),
@@ -19,6 +20,13 @@ var numberFormatPHPJS = require( './number-format' );
  */
 var decimal_point_translation_key = 'number_format_decimals',
 	thousands_sep_translation_key = 'number_format_thousands_sep';
+
+var translationLookup = [
+	// By default don't modify the options when looking up translations.
+	function( options ) {
+		return options;
+	}
+];
 
 // raise a console warning
 function warn() {
@@ -120,6 +128,20 @@ function getTranslationFromJed( jed, options ) {
 	return jed[ jedMethod ].apply( jed, jedArgs );
 }
 
+function getTranslation( i18n, options ) {
+	var translation, lookup;
+
+	for ( i = translationLookup.length - 1; i >= 0; i-- ) {
+		lookup = translationLookup[ i ]( assign( {}, options ) );
+		// Only get the translation from jed if it exists.
+		if ( i18n.state.locale[ lookup.original ] ) {
+			return getTranslationFromJed( i18n.state.jed, lookup );
+		}
+	}
+
+	return null;
+}
+
 
 function I18N() {
 	if( ! ( this instanceof I18N ) ) {
@@ -167,6 +189,37 @@ I18N.prototype.configure = function( options ) {
 };
 
 I18N.prototype.setLocale = function( localeData ) {
+	if ( localeData && localeData[ '' ] && localeData[ '' ][ 'key-hash' ] ) {
+		var transform, hashLength, keyHash = localeData[ '' ][ 'key-hash' ];
+
+		if ( keyHash.substr( 0, 4 ) === 'sha1' ) {
+			hashLength = Number ( keyHash.substr( 5 ) );
+
+			transform = function( string ) {
+				var hash = sha1( string );
+
+				if ( hashLength ) {
+					return hash.substr( 0, hashLength );
+				}
+
+				return hash;
+			};
+		}
+
+		if ( transform ) {
+			translationLookup.push( function( options ) {
+				if ( options.context ) {
+					options.original = transform( options.context + String.fromCharCode( 4 ) + options.original );
+					delete options.context;
+				} else {
+					options.original = transform( options.original );
+				}
+
+				return options;
+			} );
+		}
+	}
+
 	// if localeData is not given, assumes default locale and reset
 	if ( ! localeData || ! localeData[ '' ].localeSlug ) {
 		this.state.locale = { '': { localeSlug: this.defaultLocaleSlug } };
@@ -244,6 +297,17 @@ I18N.prototype.addTranslations = function( localeData ) {
 
 
 /**
+ * Checks whether the given original has a translation.
+ *
+ * @param  {string} original  - the string to translate
+ * @param  {string} plural  - the plural string to translate (if applicable), original used as singular
+ * @return {boolean} whether a translation exists
+ */
+I18N.prototype.hasTranslation = function() {
+	return !! getTranslation( this, normalizeTranslateArguments( arguments ) );
+}
+
+/**
  * Exposes single translation method, which is converted into its respective Jed method.
  * See sibling README
  * @param  {string} original  - the string to translate
@@ -252,22 +316,25 @@ I18N.prototype.addTranslations = function( localeData ) {
  * @return {string|React-components} translated text or an object containing React children that can be inserted into a parent component
  */
 I18N.prototype.translate = function() {
-	var options, translation, sprintfArgs, errorMethod, optionsString, cacheable;
+	var options, optionsString, translation, sprintfArgs, errorMethod, cacheable, i;
 
 	options = normalizeTranslateArguments( arguments );
 
 	cacheable = ! options.components;
-
 	if ( cacheable ) {
 		optionsString = JSON.stringify( options );
-
 		translation = this.state.translations.get( optionsString );
+		// Return the cached translation.
 		if ( translation ) {
 			return translation;
 		}
 	}
 
-	translation = getTranslationFromJed( this.state.jed, options );
+	translation = getTranslation( this, options );
+	if ( ! translation ) {
+		// In this case we need jed to give us an object with English text.
+		translation = getTranslationFromJed( this.state.jed, options );
+	}
 
 	// handle any string substitution
 	if ( options.args ) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lru": "^3.1.0",
     "moment-timezone": "0.5.11",
     "react": "0.14.8 || ^15.5.0 || ^16.0.0",
+    "sha1": "^1.1.1",
     "xgettext-js": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-adapter-react-helper": "^1.2.3",
     "mocha": "^2.4.5",
-    "react-dom": "0.14.8 || ^15.5.0 || ^16.0.0",
+    "react-dom": "^16.0.0",
     "react-test-env": "0.1.1",
-    "react-test-renderer": "^15.5.0 || ^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "rewire": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This adds support for compressed jed as defined in D10012-code. The `key-hash` in the header specifies a hash algorithm (currently only sha1 supported) and it's length, so `sha1-4` would mean that only the first 4 characters of the hex representation of the original string should be used for lookup.
