### PR TITLE
Optimize the getJedArgs function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,9 +97,9 @@ function getJedArgs( jedMethod, props ) {
 			return [ props.context, props.original, props.plural, props.count ];
 		case 'pgettext':
 			return [ props.context, props.original ];
-		default:
-			return [];
 	}
+
+	return [];
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,13 +88,18 @@ function normalizeTranslateArguments( args ) {
  * @return {[array]}           array of properties to pass into gettext-style method
  */
 function getJedArgs( jedMethod, props ) {
-	var argsByMethod = {
-		gettext: [ props.original ],
-		ngettext: [ props.original, props.plural, props.count ],
-		npgettext: [ props.context, props.original, props.plural, props.count ],
-		pgettext: [ props.context, props.original ]
-	};
-	return argsByMethod[ jedMethod ] || [];
+	switch ( jedMethod ) {
+		case 'gettext':
+			return [ props.original ];
+		case 'ngettext':
+			return [ props.original, props.plural, props.count ];
+		case 'npgettext':
+			return [ props.context, props.original, props.plural, props.count ];
+		case 'pgettext':
+			return [ props.context, props.original ];
+		default:
+			return [];
+	}
 }
 
 /**


### PR DESCRIPTION
Instead of creating an object with all variants and then throwing away all but one
of them, use a more efficient switch statement. Should deliver some speedup of a
function that's called thousands of times.