### PR TITLE
Fixed undefined iterator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.9.1
+------
+Fix a reference to an undefined value.
+
 1.9.0
 ------
 Add support for [key hashing](https://github.com/Automattic/i18n-calypso/#key-hashing) and add a method [`hasTranslation()`](https://github.com/Automattic/i18n-calypso/#hastranslation-method).

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ function getTranslationFromJed( jed, options ) {
 }
 
 function getTranslation( i18n, options ) {
-	var i, translation, lookup;
+	var i, lookup;
 
 	for ( i = translationLookup.length - 1; i >= 0; i-- ) {
 		lookup = translationLookup[ i ]( assign( {}, options ) );

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ function getTranslationFromJed( jed, options ) {
 }
 
 function getTranslation( i18n, options ) {
-	var translation, lookup;
+	var i, translation, lookup;
 
 	for ( i = translationLookup.length - 1; i >= 0; i-- ) {
 		lookup = translationLookup[ i ]( assign( {}, options ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This fixes a problem where trying to use i18n-calypso as a module in a built application would result in an `i is undefined` fatal error.

Fixes https://github.com/Automattic/jetpack/issues/9020