### PR TITLE
Safe JSON stringification for cache key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -348,11 +348,20 @@ I18N.prototype.translate = function() {
 
 	cacheable = ! options.components;
 	if ( cacheable ) {
-		optionsString = JSON.stringify( options );
-		translation = this.state.translations.get( optionsString );
-		// Return the cached translation.
-		if ( translation ) {
-			return translation;
+		// Safe JSON stringification here to catch Circular JSON error
+		// caused by passing a React component into args where only scalars are allowed
+		try {
+			optionsString = JSON.stringify( options );
+		} catch ( e ) {
+			cacheable = false;
+		}
+
+		if ( optionsString ) {
+			translation = this.state.translations.get( optionsString );
+			// Return the cached translation.
+			if ( translation ) {
+				return translation;
+			}
 		}
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -217,6 +217,15 @@ describe( 'I18n', function() {
 					}
 				) );
 			} );
+			it( 'should not throw when passed a circular object', function() {
+				var obj = { foo: 'bar', toString: function() { return 'baz'; } };
+				obj.obj = obj;
+				assert.equal( 'test1 baz', translate( 'test1 %s',
+					{
+						args: obj
+					}
+				) );
+			} );
 		} );
 
 		describe( 'with mixed components', function() {


### PR DESCRIPTION
This hotfixes the problem from https://github.com/Automattic/wp-calypso/issues/24674

…but also in general makes this function more bullet-proof as it's not considered very safe calling `JSON.stringify` on untrused data without a try/catch block.