### PR TITLE
Update: CircleCI v2 configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,9 @@
-machine:
-  node:
-    version: v6.1.0
-
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:carbon
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
Just a small PR to update circle CI to v2 configuration (v1 is deprecated).

> This project is currently running on CircleCI 1.0 which will no longer be supported after August 31, 2018. Please start migrating this project to CircleCI 2.0.

Mostly stolen from #53.