### PR TITLE
Enable babel parser plugins needed for calypso translate

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -35,7 +35,7 @@ module.exports = function( config ) {
 
 	parser = new Xgettext( {
 		keywords: parserKeywords,
-		parseOptions: { plugins: [ 'jsx', 'classProperties', 'objectRestSpread', 'exportExtensions', 'trailingFunctionCommas', 'asyncFunctions' ], allowImportExportEverywhere: true }
+		parseOptions: { plugins: [ 'jsx', 'classProperties', 'objectRestSpread', 'exportExtensions', 'exportDefaultFrom', 'exportNamespaceFrom', 'trailingFunctionCommas', 'asyncFunctions' ], allowImportExportEverywhere: true }
 	} );
 
 	function getFileMatches( inputFiles ) {


### PR DESCRIPTION
After upgrade to xgettext-js 2.0.0, in order to run
```bash
npm run translate
```

on [calypso](https://github.com/Automattic/wp-calypso), we need those additional plugins:
```
'exportDefaultFrom', 'exportNamespaceFrom'
```

From [babel-parser](https://new.babeljs.io/docs/en/next/babel-parser.html):

plugin | example
-- | --
exportDefaultFrom | `export v from "mod"` ( [calypso](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/sharing/connections/services/index.js#L2) )
exportNamespaceFrom | `export * as ns from "mod"` ( [calypso](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/woocommerce-services/api/index.js#L7) )


 
#### Testing instructions

1. Clone this repo and run `git checkout update/xgettext-version`
2. Clone wp-calypso master and run `npm install && rm -rf ./node_modules/i18n-calypso`
3. cd this repo, run `npm install && npm link`
4. cd wp-calypso and run `npm link i18n-calypso`
5. run `npm run translate`
6. assert it run to completion and you see "Done."
  
