### PR TITLE
Bumping to v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.9.2
+------
+Fixes circular reference when calling JSON.stringify with the Community Translator enabled in Calypso https://github.com/Automattic/i18n-calypso/pull/54
+
 1.9.1
 ------
 Fix a reference to an undefined value.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Bumping master to v1.9.2 after https://github.com/Automattic/i18n-calypso/pull/54

@Tug If #60 is alright with you we can get that in and update the changelog accordingly on this PR?

Once this is committed I'll commit the tag from master as well. 👍 