### PR TITLE
Update CI image to node:10 and use npm cit

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:carbon
+      - image: circleci/node:10
     steps:
       - checkout
-      - run: npm install
-      - run: npm test
+      - run: npm cit


### PR DESCRIPTION
We're migrating to Node 10 across several other codebases primarily
because it includes a more up-to-date and reliable npm version.

Node 10 will become the next LTS version.

Leverage `npm cit` shortcut that is essentially:
- npm ci (install packages) && npm t (test)