### PR TITLE
Remove moment and moment-timezone from i18n-calypso

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var I18N = require( './lib' ),
 	i18n = new I18N();
 
 module.exports = {
-	moment: i18n.moment,
 	numberFormat: i18n.numberFormat.bind( i18n ),
 	translate: i18n.translate.bind( i18n ),
 	configure: i18n.configure.bind( i18n ),

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
  */
 var debug = require( 'debug' )( 'i18n-calypso' ),
 	Jed = require( 'jed' ),
-	moment = require( 'moment-timezone' ),
 	sha1 = require( 'sha1' ),
 	EventEmitter = require( 'events' ).EventEmitter,
 	interpolateComponents = require( 'interpolate-components' ).default,
@@ -174,7 +173,6 @@ function I18N() {
 }
 
 I18N.throwErrors = false;
-I18N.prototype.moment = moment;
 
 /**
  * Formats numbers using locale settings and/or passed options
@@ -268,8 +266,6 @@ I18N.prototype.setLocale = function( localeData ) {
 			messages: this.state.locale
 		}
 	} );
-
-	moment.locale( this.state.localeSlug );
 
 	// Updates numberFormat preferences with settings from translations
 	this.state.numberFormatSettings.decimal_point = getTranslationFromJed(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1151,19 +1151,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
-    },
-    "moment-timezone": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.11.tgz",
-      "integrity": "sha1-m3bAPY71FMfkJJp7vOZJ7tOe8p8=",
-      "requires": {
-        "moment": ">= 2.6.0"
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash.assign": "^4.0.8",
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
-    "moment-timezone": "0.5.11",
     "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "sha1": "^1.1.1",
     "xgettext-js": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "1.9.1",
+  "version": "2.0.0-alpha.1",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "2.0.0-alpha.1",
+  "version": "3.0.0-alpha.1",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -306,11 +306,6 @@ describe( 'index', function() {
 			expect( output ).to.have.string( '_n( "single test2", "plural test2", 1 ),' );
 		} );
 
-		it( 'should include default translations for momentjs object', function() {
-			expect( output ).to.have.string( '__( "number_format_thousands_sep" ),' );
-			expect( output ).to.have.string( '__( "number_format_decimal_point" ),' );
-		} );
-
 		it( 'should close the php array', function() {
 			expect( output ).to.have.string( '\n);' );
 		} );

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,6 @@ var assert = require( 'assert' ),
  */
 var data = require( './data' ),
 	i18n = require( '..' ),
-	moment = i18n.moment,
 	numberFormat = i18n.numberFormat,
 	translate = i18n.translate;
 
@@ -264,29 +263,6 @@ describe( 'I18n', function() {
 				} );
 
 				assert.equal( 'not-translation1', translate( 'test-will-overwrite' ) );
-			} );
-		} );
-	} );
-
-	describe( 'moment()', function() {
-		describe( 'generating date strings', function() {
-			it( 'should know the short weekdays', function() {
-				assert.equal( 'Fr', moment( '2014-07-18' ).format( 'dd' ) );
-			} );
-			it( 'should use available translations for date format', function() {
-				assert.equal( 'Freitag, 18. Juli 2014 21:59', moment( '2014-07-18T14:59:09-07:00' ).utcOffset( '+00:00' ).format( 'LLLL' ) );
-			} );
-			it( 'should use available translations for relative time in the past', function() {
-				assert.equal( 'vor 3 Stunden', moment().subtract( 3, 'hours' ).fromNow() );
-			} );
-			it( 'should use available translations for relative time in the future', function() {
-				assert.equal( 'in ein paar Sekunden', moment().add( 10, 'seconds' ).fromNow() );
-			} );
-			it( 'should be able to convert dates to any timezone', function() {
-				assert.equal( 'Freitag, 18. Juli 2014 14:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'America/Los_Angeles' ).format( 'LLLL' ) );
-				assert.equal( 'Samstag, 19. Juli 2014 06:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'Asia/Tokyo' ).format( 'LLLL' ) );
-				assert.equal( 'Freitag, 18. Juli 2014 23:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'Europe/Paris' ).format( 'LLLL' ) );
-				assert.equal( 'Freitag, 18. Juli 2014 22:59', moment( '2014-07-18T14:59:09-07:00' ).tz( 'Europe/London' ).format( 'LLLL' ) );
 			} );
 		} );
 	} );

--- a/test/localize.js
+++ b/test/localize.js
@@ -44,7 +44,7 @@ describe( 'localize()', function() {
 		expect( LocalizedComponent.displayName ).to.equal( 'Localized(MyComponent)' );
 	} );
 
-	it( 'should provide translate, moment, and numberFormat props to rendered child', function() {
+	it( 'should provide translate and numberFormat props to rendered child', function() {
 		var MyComponent = () => emptyRender();
 		var LocalizedComponent = localize( MyComponent );
 
@@ -52,7 +52,6 @@ describe( 'localize()', function() {
 		var props = mounted.find( MyComponent ).props();
 
 		expect( props.translate ).to.be.a( 'function' );
-		expect( props.moment ).to.be.a( 'function' );
 		expect( props.numberFormat ).to.be.a( 'function' );
 	} );
 } );


### PR DESCRIPTION
Clients will now need to require them themselves to use them. This frees up clients of i18n-calypso to load moments translations and timezone data any way they see fit, or to not use moment at all.