### PR TITLE
Switch to hash.js from sha1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -201,16 +201,17 @@ I18N.prototype.setLocale = function( localeData ) {
 		var hashLength, minHashLength, maxHashLength, keyHash = localeData[ '' ][ 'key-hash' ];
 
 		var transform = function( string, hashLength ) {
-			if ( typeof hashCache[ hashLength + string ] !== 'undefined' ) {
-				return hashCache[ hashLength + string ];
+			const lookupPrefix = hashLength === false ? '' : String( hashLength );
+			if ( typeof hashCache[ lookupPrefix + string ] !== 'undefined' ) {
+				return hashCache[ lookupPrefix + string ];
 			}
 			var hash = sha1().update( string ).digest('hex');
 
 			if ( hashLength ) {
-				return hashCache[ hashLength + string ] = hash.substr( 0, hashLength );
+				return hashCache[ lookupPrefix + string ] = hash.substr( 0, hashLength );
 			}
 
-			return hashCache[ hashLength + string ] = hash;
+			return hashCache[ lookupPrefix + string ] = hash;
 		};
 
 		var generateLookup = function( hashLength ) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@
 var debug = require( 'debug' )( 'i18n-calypso' ),
 	Jed = require( 'jed' ),
 	moment = require( 'moment-timezone' ),
-	sha1 = require( 'sha1' ),
+	sha1 = require( 'hash.js/lib/hash/sha/1' ),
 	EventEmitter = require( 'events' ).EventEmitter,
 	interpolateComponents = require( 'interpolate-components' ).default,
 	LRU = require( 'lru' ),
@@ -204,7 +204,7 @@ I18N.prototype.setLocale = function( localeData ) {
 			if ( typeof hashCache[ hashLength + string ] !== 'undefined' ) {
 				return hashCache[ hashLength + string ];
 			}
-			var hash = sha1( string );
+			var hash = sha1().update( string ).digest('hex');
 
 			if ( hashLength ) {
 				return hashCache[ hashLength + string ] = hash.substr( 0, hashLength );

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,11 +197,6 @@
         "type-detect": "^1.0.0"
       }
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -292,11 +287,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "css-select": {
       "version": "1.2.0",
@@ -784,6 +774,15 @@
       "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
       "dev": true
     },
+    "hash.js": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -1092,6 +1091,11 @@
       "requires": {
         "mime-db": "~1.33.0"
       }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1648,15 +1652,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "sha1": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
-      "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
-      "requires": {
-        "charenc": ">= 0.0.1",
-        "crypt": ">= 0.0.1"
-      }
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "create-react-class": "^15.6.2",
     "debug": "^3.1.0",
     "globby": "^6.1.0",
+    "hash.js": "^1.1.5",
     "interpolate-components": "1.1.1",
     "jed": "1.0.2",
     "jstimezonedetect": "1.0.5",
@@ -33,7 +34,6 @@
     "lru": "^3.1.0",
     "moment-timezone": "0.5.11",
     "react": "0.14.8 || ^15.5.0 || ^16.0.0",
-    "sha1": "^1.1.1",
     "xgettext-js": "^2.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -328,4 +328,49 @@ describe( 'I18n', function() {
 			} );
 		} );
 	} );
+
+	describe( 'hashed locale data', function() {
+		it( 'should find keys when looked up by simple hash', function() {
+			i18n.setLocale( {
+				'': {
+					localeSlug: 'xx-pig-latin',
+					'key-hash': 'sha1'
+				},
+				'0f7d0d088b6ea936fb25b477722d734706fe8b40': [
+					null,
+					'implesa'
+				]
+			});
+			assert.equal( i18n.translate( 'simple' ), 'implesa' );
+		} );
+
+		it( 'should find keys when looked up by single length hash', function() {
+			i18n.setLocale( {
+				'': {
+					localeSlug: 'xx-pig-latin',
+					'key-hash': 'sha1-1'
+				},
+				'0': [
+					null,
+					'implesa'
+				]
+			});
+			assert.equal( i18n.translate( 'simple' ), 'implesa' );
+		} );
+
+		it( 'should find keys when looked up by multi length hash', function() {
+			i18n.setLocale( {
+				'': {
+					localeSlug: 'xx-pig-latin',
+					'key-hash': 'sha1-1-2'
+				},
+				'0': [ null,'implesa' ],
+				'78': [ null, 'edra' ],  // red has a sha1 of 78988010b890ce6f4d2136481f392787ec6d6106
+				'7d': [ null, 'reyga' ] // grey has a sha1 of 7d1f8f911da92c0ea535cad461fd773281a79638
+			});
+			assert.equal( i18n.translate( 'simple' ), 'implesa' );
+			assert.equal( i18n.translate( 'red' ), 'edra' );
+			assert.equal( i18n.translate( 'grey' ), 'reyga' );
+		} );
+	} );
 } );


### PR DESCRIPTION
`hash.js`, using just `sha1` is 2.3k gzipped, while `sha1` is 8k. 

Switch to save some bytes and align with what calypso uses.