### PR TITLE
Update the parse options to support what calypso uses

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -35,19 +35,19 @@ module.exports = function( config ) {
 
 	parser = new Xgettext( {
 		keywords: parserKeywords,
-		parseOptions: { 
-			plugins: [ 
-				'jsx', 
-				'classProperties', 
-				'objectRestSpread', 
-				'exportExtensions', 
-				'trailingFunctionCommas', 
+		parseOptions: {
+			plugins: [
 				'asyncFunctions',
-				'exportNamespaceFrom',
+				'classProperties',
+				'dynamicImport',
 				'exportDefaultFrom',
-				'dynamicImport'
-			], 
-			allowImportExportEverywhere: true 
+				'exportExtensions',
+				'exportNamespaceFrom',
+				'jsx',
+				'objectRestSpread',
+				'trailingFunctionCommas'
+			],
+			allowImportExportEverywhere: true
 		}
 	} );
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -35,7 +35,20 @@ module.exports = function( config ) {
 
 	parser = new Xgettext( {
 		keywords: parserKeywords,
-		parseOptions: { plugins: [ 'jsx', 'classProperties', 'objectRestSpread', 'exportExtensions', 'trailingFunctionCommas', 'asyncFunctions' ], allowImportExportEverywhere: true }
+		parseOptions: { 
+			plugins: [ 
+				'jsx', 
+				'classProperties', 
+				'objectRestSpread', 
+				'exportExtensions', 
+				'trailingFunctionCommas', 
+				'asyncFunctions',
+				'exportNamespaceFrom',
+				'exportDefaultFrom',
+				'dynamicImport'
+			], 
+			allowImportExportEverywhere: true 
+		}
 	} );
 
 	function getFileMatches( inputFiles ) {


### PR DESCRIPTION
Add exportDefaultFrom, exportNamespaceFrom, and dynamicImport.