### PR TITLE
Make the moment-timezone version less restrictive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1151,16 +1151,16 @@
       }
     },
     "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.11.tgz",
-      "integrity": "sha1-m3bAPY71FMfkJJp7vOZJ7tOe8p8=",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
       "requires": {
-        "moment": ">= 2.6.0"
+        "moment": ">= 2.9.0"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash.assign": "^4.0.8",
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
-    "moment-timezone": "^0.5.21",
+    "moment-timezone": "^0.5.16",
     "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "xgettext-js": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash.assign": "^4.0.8",
     "lodash.flatten": "^4.4.0",
     "lru": "^3.1.0",
-    "moment-timezone": "0.5.11",
+    "moment-timezone": "^0.5.21",
     "react": "0.14.8 || ^15.5.0 || ^16.0.0",
     "xgettext-js": "^2.0.0"
   },


### PR DESCRIPTION
Open up the range a bit so that downstream folks can resolve the moment-timezone they want on the 0.5 line. This is currently conflicting with the moment-timezone in Gutenberg, which is spec'd to `^0.5.16`. 