### PR TITLE
Prep for 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.0.2
+------
+
+* In localize module, passing down `locale` as default prop to wrapped component [#77](https://github.com/Automattic/i18n-calypso/pull/77).
+
 2.0.1
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 2.0.2
 ------
 
-* In localize module, passing down `locale` as default prop to wrapped component [#77](https://github.com/Automattic/i18n-calypso/pull/77).
+* The localize HoC will now pass down the current locale slug as a `locale` prop to the wrapped component [#77](https://github.com/Automattic/i18n-calypso/pull/77).
+* Open up the range on the moment-timezone dependency to allow clients to use any moment-timezone from the 0.5 range. [#78](https://github.com/Automattic/i18n-calypso/pull/78)
 
 2.0.1
 ------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-calypso",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "i18n JavaScript library on top of Jed originally used in Calypso",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Updating patch number and changelog.

### Changes:

In #77 we merged an important change to the `localize` props, which allows us to inform wrapped PureComponents of a locale switch.

